### PR TITLE
Extend the sampling of job characterstica

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(%s)
 add_definitions("-Wall -Wno-unused-variable -Wno-unused-private-field")
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 
@@ -73,5 +75,7 @@ target_link_libraries(dc-sim
                        ${Boost_LIBRARIES}
                       )
 endif()
+
+# set_property(TARGET dc-sim PROPERTY CXX_STANDARD 17)
 
 install(TARGETS dc-sim DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -71,23 +71,38 @@ there is also the option to provide a JSON file, which contains all necessary in
 ```bash
 --workload-configurations <path_to_workload_json>
 ```
-The workloads should contain the full information as it would be set via the command line, e.g.:
+The workloads have to contain the full information. 
+Opposed to as it would be set via the command line, where only gaussian distributed job characteristics are supported, in the workload file also distributions according to a histogram can be used.
+An example for a workload mixing both gaussian and histogram distributions of its job characteristics would be, e.g.:
 ```json
 {
-    "stream_and_compute_workload": {
+    "calc_workload": {
         "num_jobs": 60,
-        "infiles_per_job": 10,
-        "average_flops": 2164428000000,
-        "sigma_flops": 216442800000,
-        "average_memory": 2000000000,
-        "sigma_memory": 200000000,
-        "average_infile_size": 3600000000,
-        "sigma_infile_size": 360000000,
-        "average_outfile_size": 18000000000,
-        "sigma_outfile_size": 1800000000,
-        "workload_type": "streaming"
+        "infiles_per_job": 0,
+        "flops": {
+            "type": "histogram",
+            "bins": [1164428000000,2164428000000,3164428000000],
+            "counts": [50,50]
+        },
+        "memory": {
+            "type": "gaussian",
+            "average": 2000000000,
+            "sigma": 200000000
+        },
+        "infilesize": {
+            "type": "gaussian",
+            "average": 0,
+            "sigma": 0
+        },
+        "outfilesize": {
+            "type": "gaussian",
+            "average": 18000000,
+            "sigma": 1800000
+        },
+        "workload_type": "calculation",
+        "submission_time": 0
     }
 }
 ```
-It is also possible to give a list of workload configuration files, which enables to simulate the execution of multiple sets of workloads.
-Example configuration file covering different workload-types are given in `data/workload-configs/workload_testsuite.json`.
+It is also possible to give a list of workload configuration files and configure more than one workload per file, which enables to simulate the execution of multiple sets of workloads in the same simulation run.
+Example configurations covering different workload-types is given in `data/workload-configs/workload_testsuite.json`.

--- a/data/workload-configs/crown_ttbar_validation.json
+++ b/data/workload-configs/crown_ttbar_validation.json
@@ -2,14 +2,26 @@
     "crown_ttbar_validation": {
         "num_jobs": 1,
         "infiles_per_job": 20,
-        "average_flops": 2886000000000,
-        "sigma_flops": 0,
-        "average_memory": 2400,
-        "sigma_memory": 0,
-        "average_infile_size": 427718950,
-        "sigma_infile_size": 0,
-        "average_outfile_size": 16000000,
-        "sigma_outfile_size": 0,
+        "flops": {
+            "type": "gaussian",
+            "average": 2886000000000,
+            "sigma": 0
+        },
+        "memory": {
+            "type": "gaussian",
+            "average": 2400,
+            "sigma": 0
+        },
+        "infilesize": {
+            "type": "gaussian",
+            "average": 427718950,
+            "sigma": 0
+        },
+        "outfilesize": {
+            "type": "gaussian",
+            "average": 16000000,
+            "sigma": 0
+        },
         "workload_type": "streaming",
         "submission_time": 10
     }

--- a/data/workload-configs/workflow_testsuite.json
+++ b/data/workload-configs/workflow_testsuite.json
@@ -2,56 +2,104 @@
     "calc_workload": {
         "num_jobs": 60,
         "infiles_per_job": 0,
-        "average_flops": 2164428000000,
-        "sigma_flops": 216442800000,
-        "average_memory": 2000000000,
-        "sigma_memory": 200000000,
-        "average_infile_size": 0,
-        "sigma_infile_size": 0,
-        "average_outfile_size": 18000000,
-        "sigma_outfile_size": 1800000,
+        "flops": {
+            "type": "histogram",
+            "bins": [1164428000000,2164428000000,3164428000000],
+            "counts": [50,50]
+        },
+        "memory": {
+            "type": "gaussian",
+            "average": 2000000000,
+            "sigma": 200000000
+        },
+        "infilesize": {
+            "type": "gaussian",
+            "average": 0,
+            "sigma": 0
+        },
+        "outfilesize": {
+            "type": "gaussian",
+            "average": 18000000,
+            "sigma": 1800000
+        },
         "workload_type": "calculation",
         "submission_time": 0
     },
     "mc_workload": {
         "num_jobs": 60,
         "infiles_per_job": 0,
-        "average_flops": 2164428000000,
-        "sigma_flops": 216442800000,
-        "average_memory": 2000000000,
-        "sigma_memory": 200000000,
-        "average_infile_size": 0,
-        "sigma_infile_size": 0,
-        "average_outfile_size": 18000000000,
-        "sigma_outfile_size": 1800000000,
+        "flops": {
+            "type": "gaussian",
+            "average": 2164428000000,
+            "sigma": 216442800000
+        },
+        "memory": {
+            "type": "gaussian",
+            "average": 2000000000,
+            "sigma": 200000000
+        },
+        "infilesize": {
+            "type": "gaussian",
+            "average": 0,
+            "sigma": 0
+        },
+        "outfilesize": {
+            "type": "gaussian",
+            "average": 18000000000,
+            "sigma": 1800000000
+        },
         "workload_type": "calculation",
         "submission_time": 10000
     },
     "copy_and_compute_workload": {
         "num_jobs": 60,
         "infiles_per_job": 10,
-        "average_flops": 2164428000000,
-        "sigma_flops": 216442800000,
-        "average_memory": 2000000000,
-        "sigma_memory": 200000000,
-        "average_infile_size": 3600000000,
-        "sigma_infile_size": 360000000,
-        "average_outfile_size": 18000000000,
-        "sigma_outfile_size": 1800000000,
+        "flops": {
+            "type": "gaussian",
+            "average": 2164428000000,
+            "sigma": 216442800000
+        },
+        "memory": {
+            "type": "gaussian",
+            "average": 2000000000,
+            "sigma": 200000000
+        },
+        "infilesize": {
+            "type": "gaussian",
+            "average": 3600000000,
+            "sigma": 360000000
+        },
+        "outfilesize": {
+            "type": "gaussian",
+            "average": 18000000000,
+            "sigma": 1800000000
+        },
         "workload_type": "copy",
         "submission_time": 20000
     },
     "stream_and_compute_workload": {
         "num_jobs": 60,
         "infiles_per_job": 10,
-        "average_flops": 2164428000000,
-        "sigma_flops": 216442800000,
-        "average_memory": 2000000000,
-        "sigma_memory": 200000000,
-        "average_infile_size": 3600000000,
-        "sigma_infile_size": 360000000,
-        "average_outfile_size": 18000000000,
-        "sigma_outfile_size": 1800000000,
+        "flops": {
+            "type": "gaussian",
+            "average": 2164428000000,
+            "sigma": 216442800000
+        },
+        "memory": {
+            "type": "gaussian",
+            "average": 2000000000,
+            "sigma": 200000000
+        },
+        "infilesize": {
+            "type": "gaussian",
+            "average": 3600000000,
+            "sigma": 360000000
+        },
+        "outfilesize": {
+            "type": "gaussian",
+            "average": 18000000000,
+            "sigma": 1800000000
+        },
         "workload_type": "streaming",
         "submission_time": 55000.5
     }

--- a/src/SimpleSimulator.cpp
+++ b/src/SimpleSimulator.cpp
@@ -33,10 +33,7 @@ namespace po = boost::program_options;
  */
 const std::vector<std::string> workload_keys = {
         "num_jobs","infiles_per_job",
-        "average_flops","sigma_flops",
-        "average_memory", "sigma_memory",
-        "average_infile_size", "sigma_infile_size",
-        "average_outfile_size", "sigma_outfile_size",
+        "flops", "memory", "infilesize", "outfilesize",
         "workload_type", "submission_time"
     };
 std::map<std::shared_ptr<wrench::StorageService>, LRU_FileList> SimpleSimulator::global_file_map;
@@ -504,7 +501,7 @@ int main(int argc, char **argv) {
     std::vector<Workload> workload_specs = {};
 
     if(workload_configurations.size() == 0){
-        std::cerr << "Trying to create a single workload from CLI parameters, consider using a workload config instead...";
+        std::cerr << "Trying to create a single workload from CLI parameters, consider using a workload config instead..." << std::endl;
         workload_specs.push_back(
             Workload(
                 num_jobs, infiles_per_job,
@@ -523,6 +520,7 @@ int main(int argc, char **argv) {
     else {
         for(auto &wf_confpath : workload_configurations){
             std::ifstream wf_conf(wf_confpath);
+            if(!wf_conf.is_open()) throw std::runtime_error("File " + wf_confpath + " could not be opened!");
             nlohmann::json wfs_json = nlohmann::json::parse(wf_conf);
 
             // Looping over the multiple workloads configured in the json file

--- a/src/SimpleSimulator.cpp
+++ b/src/SimpleSimulator.cpp
@@ -542,10 +542,8 @@ int main(int argc, char **argv) {
                 workload_specs.push_back(
                     Workload(
                         wf.value()["num_jobs"], wf.value()["infiles_per_job"],
-                        wf.value()["average_flops"], wf.value()["sigma_flops"],
-                        wf.value()["average_memory"], wf.value()["sigma_memory"],
-                        wf.value()["average_infile_size"], wf.value()["sigma_infile_size"],
-                        wf.value()["average_outfile_size"], wf.value()["sigma_outfile_size"],
+                        wf.value()["flops"], wf.value()["memory"],
+                        wf.value()["infilesize"], wf.value()["outfilesize"],
                         get_workload_type(workload_type_lower), wf.key(),
                         wf.value()["submission_time"],
                         SimpleSimulator::gen

--- a/src/SimpleSimulator.cpp
+++ b/src/SimpleSimulator.cpp
@@ -504,6 +504,7 @@ int main(int argc, char **argv) {
     std::vector<Workload> workload_specs = {};
 
     if(workload_configurations.size() == 0){
+        std::cerr << "Trying to create a single workload from CLI parameters, consider using a workload config instead...";
         workload_specs.push_back(
             Workload(
                 num_jobs, infiles_per_job,

--- a/src/Workload.cpp
+++ b/src/Workload.cpp
@@ -2,6 +2,8 @@
 
 #include "Workload.h"
 
+XBT_LOG_NEW_DEFAULT_CATEGORY(workload, "Log category for WorkloadExecutionController");
+
 
 #define F(type) #type ,
 const char* workload_type_names[] = { WORKLOAD_TYPES( F ) nullptr };
@@ -103,4 +105,113 @@ Workload::Workload(
     this->job_batch = batch;
     this->workload_type = workload_type;
     this->submit_arrival_time = arrival_time;
+}
+
+/**
+ * @brief Fill a Workload consisting of jobs with job specifications, 
+ * which include the inputfile and outputfile dependencies.
+ * It can be chosen between jobs streaming input data and perform computations simultaneously 
+ * or jobs copying the full input-data and compute afterwards.
+ *    
+ * @param num_jobs: number of tasks
+ * @param infiles_per_task: number of input-files each job processes
+ * @param flops: json object containing type and parameters for the flops distribution
+ * @param memory: json object containing type and parameters for the memory distribution
+ * @param infile_size: json object containing type and parameters for the input-file size distribution
+ * @param outfile_size: json object containing type and parameters for the output-file size distribution
+ * @param workload_type: flag to specifiy, whether the job should run with streaming or not
+ * @param name_suffix: part of job name to distinguish between different workloads
+ * @param arrival_time: submission time offset relative to simulation start
+ * @param generator: random number generator objects to draw from
+ * 
+ * @throw std::runtime_error
+ */
+Workload::Workload(
+        const size_t num_jobs,
+        const size_t infiles_per_job,
+        nlohmann::json flops,
+        nlohmann::json memory,
+        nlohmann::json infile_size,
+        nlohmann::json outfile_size,
+        const enum WorkloadType workload_type, const std::string name_suffix,
+        const double arrival_time,
+        const std::mt19937& generator
+) {
+    this->generator = generator;
+    // Map to store the workload specification
+    std::vector<JobSpecification> batch;
+    std::string potential_separator = "_";
+    if(name_suffix == ""){
+        potential_separator = "";
+    }
+
+    // Initialize random number generators
+    this->flops_dist = [&]() {
+        if(flops["type"]=="gaussian") {
+            return std::normal_distribution<double>(flops["average"],flops["sigma"])(this->generator);
+        } else if(flops["type"]=="histogram") {
+            return std::piecewise_constant_distribution<double>(flops["bins"].begin(),flops["bins"].end(),flops["counts"].begin())(this->generator);
+        } else {
+            throw std::runtime_error("Random number generation for type " + std::string(flops["type"]) + " not implemented!");
+        }
+    };
+    this->mem_dist = Workload::initializeRNG(memory);
+    this->insize_dist = Workload::initializeRNG(infile_size);
+    this->outsize_dist = Workload::initializeRNG(outfile_size);
+
+    for (size_t j = 0; j < num_jobs; j++) {
+        batch.push_back(sampleJob(j, infiles_per_job, name_suffix, potential_separator));
+    }
+
+    this->job_batch = batch;
+    this->workload_type = workload_type;
+    this->submit_arrival_time = arrival_time;
+}
+
+
+std::function<double()> Workload::initializeRNG(nlohmann::json json) {
+    std::function<double()> dist = [&]() {
+        if(json["type"]=="gaussian") {
+            return std::normal_distribution<double>(json["average"],json["sigma"])(this->generator);
+        } else if(json["type"]=="histogram") {
+            return std::piecewise_constant_distribution<double>(json["bins"].begin(),json["bins"].end(),json["counts"].begin())(this->generator);
+        } else {
+            throw std::runtime_error("Random number generation for type " + std::string(json["type"]) + " not implemented!");
+        }
+    };
+    return dist;
+}
+
+
+JobSpecification Workload::sampleJob(size_t job_id, const size_t infiles_per_job, std::string name_suffix, std::string potential_separator) {
+    // Create a job specification
+    JobSpecification job_specification;
+
+    size_t j = job_id;
+
+    // Sample strictly positive task flops
+    double dflops = this->flops_dist();
+    while (dflops < 0.) dflops = this->flops_dist();
+    job_specification.total_flops = dflops;
+
+    // Sample strictly positive task memory requirements
+    double dmem = this->mem_dist();
+    while (dmem < 0.) dmem = this->mem_dist();
+    job_specification.total_mem = dmem;
+
+    for (size_t f = 0; f < infiles_per_job; f++) {
+        // Sample strictly positive inputfile sizes
+        double dinsize = this->insize_dist();
+        while (dinsize < 0.) dinsize = this->insize_dist();
+        job_specification.infiles.push_back(wrench::Simulation::addFile("infile_" + name_suffix + potential_separator + std::to_string(j) + "_" + std::to_string(f), dinsize));
+    }
+
+    // Sample outfile sizes
+    double doutsize = this->outsize_dist();
+    while (doutsize < 0.) doutsize = this->outsize_dist();
+    job_specification.outfile = wrench::Simulation::addFile("outfile_" + name_suffix + potential_separator + std::to_string(j), doutsize);
+
+    job_specification.jobid = "job_" + name_suffix + potential_separator + std::to_string(j);
+
+    return job_specification;
 }

--- a/src/Workload.h
+++ b/src/Workload.h
@@ -87,12 +87,12 @@ class Workload {
     private:
         /** @brief generator to shuffle jobs **/
         std::mt19937 generator;
-        std::function<double()> flops_dist;
-        std::function<double()> mem_dist;
-        std::function<double()> insize_dist;
-        std::function<double()> outsize_dist;
+        std::function<double(std::mt19937&)> flops_dist;
+        std::function<double(std::mt19937&)> mem_dist;
+        std::function<double(std::mt19937&)> insize_dist;
+        std::function<double(std::mt19937&)> outsize_dist;
 
-        std::function<double()> initializeRNG(nlohmann::json json);
+        std::function<double(std::mt19937&)> initializeRNG(nlohmann::json json);
 
         JobSpecification sampleJob(const size_t job_id, const size_t infiles_per_job, std::string name_suffix, std::string potential_separator);
 };

--- a/src/Workload.h
+++ b/src/Workload.h
@@ -5,6 +5,12 @@
 #include "JobSpecification.h"
 #include "util/Utils.h"
 
+// #include <variant>
+
+#include <boost/regex.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
+
 
 #define WORKLOAD_TYPES( F ) \
     F(Calculation) \
@@ -59,6 +65,18 @@ class Workload {
             const std::mt19937& generator
         );
 
+        Workload(
+            const size_t num_jobs,
+            const size_t infiles_per_job,
+            nlohmann::json flops,
+            nlohmann::json memory,
+            nlohmann::json infile_size,
+            nlohmann::json outfile_size,
+            const WorkloadType workload_type, const std::string name_suffix,
+            const double arrival_time,
+            const std::mt19937& generator
+        );
+
         // job list with specifications
         std::vector<JobSpecification> job_batch;
         // Usage of block streaming
@@ -69,6 +87,14 @@ class Workload {
     private:
         /** @brief generator to shuffle jobs **/
         std::mt19937 generator;
+        std::function<double()> flops_dist;
+        std::function<double()> mem_dist;
+        std::function<double()> insize_dist;
+        std::function<double()> outsize_dist;
+
+        std::function<double()> initializeRNG(nlohmann::json json);
+
+        JobSpecification sampleJob(const size_t job_id, const size_t infiles_per_job, std::string name_suffix, std::string potential_separator);
 };
 
 


### PR DESCRIPTION
Extend the sampling of job characteristica for workloads to support gaussian as well as piecewise constant probability distributions. This also involves changes in the way of configuring the workloads' steering files. The example steering file has been adjusted to give an example for both cases. The old configuration style is left only for CLI parameter configuration. CLI configuration only supports gaussian probability distributions for job characteristics.