### PR TITLE
Enable simulation of scheduling and executing multi-core jobs

### DIFF
--- a/data/workload-configs/crown_ttbar_validation.json
+++ b/data/workload-configs/crown_ttbar_validation.json
@@ -2,6 +2,10 @@
     "crown_ttbar_validation": {
         "num_jobs": 1,
         "infiles_per_job": 20,
+        "cores": {
+            "type": "histogram",
+            "counts": [0,1]
+        },
         "flops": {
             "type": "gaussian",
             "average": 2886000000000,

--- a/data/workload-configs/workflow_testsuite.json
+++ b/data/workload-configs/workflow_testsuite.json
@@ -2,6 +2,10 @@
     "calc_workload": {
         "num_jobs": 60,
         "infiles_per_job": 0,
+        "cores": {
+            "type": "poisson",
+            "mu": 1
+        },
         "flops": {
             "type": "histogram",
             "bins": [1164428000000,2164428000000,3164428000000],
@@ -28,6 +32,11 @@
     "mc_workload": {
         "num_jobs": 60,
         "infiles_per_job": 0,
+        "cores": {
+            "type": "histogram",
+            "bins": [-0.5,0.5,1.5],
+            "counts": [0,1]
+        },
         "flops": {
             "type": "gaussian",
             "average": 2164428000000,
@@ -54,6 +63,10 @@
     "copy_and_compute_workload": {
         "num_jobs": 60,
         "infiles_per_job": 10,
+        "cores": {
+            "type": "histogram",
+            "counts": [0,2]
+        },
         "flops": {
             "type": "gaussian",
             "average": 2164428000000,
@@ -80,6 +93,10 @@
     "stream_and_compute_workload": {
         "num_jobs": 60,
         "infiles_per_job": 10,
+        "cores": {
+            "type": "histogram",
+            "counts": [0,1]
+        },
         "flops": {
             "type": "gaussian",
             "average": 2164428000000,

--- a/src/JobSpecification.h
+++ b/src/JobSpecification.h
@@ -21,6 +21,8 @@ public:
     std::shared_ptr<wrench::DataFile> outfile;
     // Desired destination of the output file to be written to
     std::shared_ptr<wrench::FileLocation> outfile_destination;
+    // Number of cores to run on
+    int cores;
     // Total number of FLOPS to be computed for the job to finish
     double total_flops;
     // Memory consumption of the job

--- a/src/SimpleSimulator.h
+++ b/src/SimpleSimulator.h
@@ -32,6 +32,8 @@ public:
     static double xrd_block_size;
     static std::mt19937 gen;
 
+    // Cores required
+    static int req_cores;
     // Flops distribution
     static double mean_flops;
     static double sigma_flops;

--- a/src/Workload.cpp
+++ b/src/Workload.cpp
@@ -202,7 +202,7 @@ std::function<int(std::mt19937&)> Workload::initializeIntRNG(nlohmann::json json
     } else if(json["type"].get<std::string>()=="histogram") {
         auto bins = json["bins"].get<std::vector<double>>();
         if(!bins.empty()) WRENCH_WARN("Ignoring configured bins for integer distribution!");
-        auto weights = json["weights"].get<std::vector<int>>();
+        auto weights = json["counts"].get<std::vector<int>>();
         // std::cerr << "bins: " << json["bins"] << ", weights: " << json["counts"] << std::endl;
         dist = [weights](std::mt19937& generator){
             return std::discrete_distribution<int>(weights.begin(), weights.end())(generator);

--- a/src/Workload.cpp
+++ b/src/Workload.cpp
@@ -48,8 +48,8 @@ std::string workload_type_to_string( WorkloadType workload )
  */
 Workload::Workload(
         const size_t num_jobs,
-        const int request_cores,
         const size_t infiles_per_task,
+        const int request_cores,
         const double average_flops, const double sigma_flops,
         const double average_memory, const double sigma_memory,
         const double average_infile_size, const double sigma_infile_size,

--- a/src/Workload.cpp
+++ b/src/Workload.cpp
@@ -200,8 +200,11 @@ std::function<int(std::mt19937&)> Workload::initializeIntRNG(nlohmann::json json
             return std::poisson_distribution<int>(mu)(generator);
         };
     } else if(json["type"].get<std::string>()=="histogram") {
-        auto bins = json["bins"].get<std::vector<double>>();
-        if(!bins.empty()) WRENCH_WARN("Ignoring configured bins for integer distribution!");
+        try{
+            auto bins = json["bins"].get<std::vector<double>>();
+            WRENCH_WARN("Ignoring configured bins for integer distribution!");
+        }
+        catch(...) {}
         auto weights = json["counts"].get<std::vector<int>>();
         // std::cerr << "bins: " << json["bins"] << ", weights: " << json["counts"] << std::endl;
         dist = [weights](std::mt19937& generator){

--- a/src/Workload.cpp
+++ b/src/Workload.cpp
@@ -48,6 +48,7 @@ std::string workload_type_to_string( WorkloadType workload )
  */
 Workload::Workload(
         const size_t num_jobs,
+        const int request_cores,
         const size_t infiles_per_task,
         const double average_flops, const double sigma_flops,
         const double average_memory, const double sigma_memory,
@@ -75,6 +76,9 @@ Workload::Workload(
 
         // Create a job specification
         JobSpecification job_specification;
+
+        // Set number of requested cores
+        job_specification.cores = request_cores;
 
         // Sample strictly positive task flops
         double dflops = flops_dist(this->generator);
@@ -129,6 +133,7 @@ Workload::Workload(
 Workload::Workload(
         const size_t num_jobs,
         const size_t infiles_per_job,
+        nlohmann::json cores,
         nlohmann::json flops,
         nlohmann::json memory,
         nlohmann::json infile_size,
@@ -146,10 +151,11 @@ Workload::Workload(
     }
 
     // Initialize random number generators
-    this->flops_dist = Workload::initializeRNG(flops);
-    this->mem_dist = Workload::initializeRNG(memory);
-    this->insize_dist = Workload::initializeRNG(infile_size);
-    this->outsize_dist = Workload::initializeRNG(outfile_size);
+    this->core_dist = Workload::initializeIntRNG(cores);
+    this->flops_dist = Workload::initializeDoubleRNG(flops);
+    this->mem_dist = Workload::initializeDoubleRNG(memory);
+    this->insize_dist = Workload::initializeDoubleRNG(infile_size);
+    this->outsize_dist = Workload::initializeDoubleRNG(outfile_size);
 
     for (size_t j = 0; j < num_jobs; j++) {
         batch.push_back(sampleJob(j, infiles_per_job, name_suffix, potential_separator));
@@ -161,7 +167,7 @@ Workload::Workload(
 }
 
 
-std::function<double(std::mt19937&)> Workload::initializeRNG(nlohmann::json json) {
+std::function<double(std::mt19937&)> Workload::initializeDoubleRNG(nlohmann::json json) {
     // std::cerr << json["type"] << ": ";
     std::function<double(std::mt19937&)> dist;
     if(json["type"].get<std::string>()=="gaussian") {
@@ -179,7 +185,30 @@ std::function<double(std::mt19937&)> Workload::initializeRNG(nlohmann::json json
             return std::piecewise_constant_distribution<double>(bins.begin(),bins.end(),weights.begin())(generator);
         };
     } else {
-        throw std::runtime_error("Random number generation for type " + json["type"].get<std::string>() + " not implemented!");
+        throw std::runtime_error("Random number generation for type " + json["type"].get<std::string>() + " not implemented for real valued distributions!");
+    }
+    return dist;
+}
+
+std::function<int(std::mt19937&)> Workload::initializeIntRNG(nlohmann::json json) {
+    // std::cerr << json["type"] << ": ";
+    std::function<int(std::mt19937&)> dist;
+    if(json["type"].get<std::string>()=="poisson") {
+        int mu = json["mu"].get<int>();
+        // std::cerr << "ave: "<< ave << ", stddev: " << sigma << std::endl;
+        dist = [mu](std::mt19937& generator){
+            return std::poisson_distribution<int>(mu)(generator);
+        };
+    } else if(json["type"].get<std::string>()=="histogram") {
+        auto bins = json["bins"].get<std::vector<double>>();
+        if(!bins.empty()) WRENCH_WARN("Ignoring configured bins for integer distribution!");
+        auto weights = json["weights"].get<std::vector<int>>();
+        // std::cerr << "bins: " << json["bins"] << ", weights: " << json["counts"] << std::endl;
+        dist = [weights](std::mt19937& generator){
+            return std::discrete_distribution<int>(weights.begin(), weights.end())(generator);
+        };
+    } else {
+        throw std::runtime_error("Random number generation for type " + json["type"].get<std::string>() + " not implemented for integer valued distributions!");
     }
     return dist;
 }
@@ -190,6 +219,10 @@ JobSpecification Workload::sampleJob(size_t job_id, const size_t infiles_per_job
     JobSpecification job_specification;
 
     size_t j = job_id;
+
+    // Sample number of cores to run on
+    int req_cores = this->core_dist(this->generator);
+    job_specification.cores = req_cores;
 
     // Sample strictly positive task flops
     double dflops = this->flops_dist(this->generator);

--- a/src/Workload.cpp
+++ b/src/Workload.cpp
@@ -222,6 +222,7 @@ JobSpecification Workload::sampleJob(size_t job_id, const size_t infiles_per_job
 
     // Sample number of cores to run on
     int req_cores = this->core_dist(this->generator);
+    while (req_cores < 1) req_cores = this->core_dist(this->generator);
     job_specification.cores = req_cores;
 
     // Sample strictly positive task flops

--- a/src/Workload.h
+++ b/src/Workload.h
@@ -55,8 +55,8 @@ class Workload {
         // Constructor
         Workload(
             const size_t num_jobs,
-            const int request_cores,
             const size_t infiles_per_task,
+            const int request_cores,
             const double average_flops, const double sigma_flops,
             const double average_memory, const double sigma_memory,
             const double average_infile_size, const double sigma_infile_size,

--- a/src/Workload.h
+++ b/src/Workload.h
@@ -55,6 +55,7 @@ class Workload {
         // Constructor
         Workload(
             const size_t num_jobs,
+            const int request_cores,
             const size_t infiles_per_task,
             const double average_flops, const double sigma_flops,
             const double average_memory, const double sigma_memory,
@@ -68,6 +69,7 @@ class Workload {
         Workload(
             const size_t num_jobs,
             const size_t infiles_per_job,
+            nlohmann::json cores,
             nlohmann::json flops,
             nlohmann::json memory,
             nlohmann::json infile_size,
@@ -87,12 +89,14 @@ class Workload {
     private:
         /** @brief generator to shuffle jobs **/
         std::mt19937 generator;
+        std::function<int(std::mt19937&)> core_dist;
         std::function<double(std::mt19937&)> flops_dist;
         std::function<double(std::mt19937&)> mem_dist;
         std::function<double(std::mt19937&)> insize_dist;
         std::function<double(std::mt19937&)> outsize_dist;
 
-        std::function<double(std::mt19937&)> initializeRNG(nlohmann::json json);
+        std::function<int(std::mt19937&)> initializeIntRNG(nlohmann::json json);
+        std::function<double(std::mt19937&)> initializeDoubleRNG(nlohmann::json json);
 
         JobSpecification sampleJob(const size_t job_id, const size_t infiles_per_job, std::string name_suffix, std::string potential_separator);
 };


### PR DESCRIPTION
This extends the simulator to enable simulation of multicore jobs. The HTCondor inspired scheduler implemented in WRENCH is used to handle the matching of resources. It is assumed that the speed-up of the jobs' execution is equal to the number of cores assigned to each job.