### PR TITLE
Allow bandwidth fluctuations for simulating influence by alien platform entities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,6 @@ include_directories(src/ ${SimGrid_INCLUDE_DIR}/include /usr/local/include /opt/
 set(SOURCE_FILES
         src/WorkloadExecutionController.h
         src/WorkloadExecutionController.cpp
-        src/SimpleExecutionController.h
-        src/SimpleExecutionController.cpp
         src/BandwidthModifier.h
         src/BandwidthModifier.cpp
         src/SimpleSimulator.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ include_directories(src/ ${SimGrid_INCLUDE_DIR}/include /usr/local/include /opt/
 set(SOURCE_FILES
         src/WorkloadExecutionController.h
         src/WorkloadExecutionController.cpp
+        src/SimpleExecutionController.h
+        src/SimpleExecutionController.cpp
+        src/BandwidthModifier.h
+        src/BandwidthModifier.cpp
         src/SimpleSimulator.h
         src/SimpleSimulator.cpp
         src/JobSpecification.h

--- a/src/BandwidthModifier.cpp
+++ b/src/BandwidthModifier.cpp
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2020. <ADD YOUR HEADER INFORMATION>.
+ * Generated with the wrench-init.in tool.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#include <iostream>
+#include <algorithm>
+
+#include "BandwidthModifier.h"
+
+XBT_LOG_NEW_DEFAULT_CATEGORY(bandwidth_modifier, "Log category for BandwidthModifier");
+
+/**
+ *  @brief A "controller" that dynamically modifies a link's bandwidth
+ * 
+ *  @param hostname: the host on which this actor runs
+ *  @param link_name: the name of the link whose bandwidth is to be modified
+ *  @param period: the period in between two bandwidth modifications (in seconds)
+ *  @param distribution: the normal distribution from which to same bandwidth modification values
+ */
+BandwidthModifier::BandwidthModifier(
+        const std::string &hostname,
+        const std::string &link_name,
+        double period,
+        std::normal_distribution<double>* distribution,
+        unsigned long seed) : wrench::ExecutionController(
+        hostname,
+        "bandwidth-modifier"), link_name(link_name), period(period), distribution(distribution), seed(seed) {
+
+}
+
+/**
+ * @brief main method of the BandwidthModifier actor
+ * 
+ * @return 0 on completion
+ * 
+ * @throw std::runtime_error
+ */
+int BandwidthModifier::main() {
+
+    wrench::TerminalOutput::setThisProcessLoggingColor(wrench::TerminalOutput::COLOR_GREEN);
+
+    // Retrieve the link
+    auto the_link = simgrid::s4u::Link::by_name_or_null(this->link_name);
+    if (the_link == nullptr) {
+        throw std::invalid_argument("BandwidthModifier::main(): The platform does not contain a link named '" + this->link_name +"'");
+    }
+
+    // Get its (original) bandwidth
+    auto original_bandwidth = the_link->get_bandwidth();
+
+    // Create RNG
+    std::mt19937 rng(this->seed);
+
+    while (true) {
+        // Sleep during the period
+        wrench::Simulation::sleep(period);
+        // Sample bandwidth modification factor
+        double factor = (*this->distribution)(rng);
+        // Update the link bandwidth
+        the_link->set_bandwidth(original_bandwidth * factor);
+    }
+}
+

--- a/src/BandwidthModifier.h
+++ b/src/BandwidthModifier.h
@@ -17,7 +17,7 @@
 #include "JobSpecification.h"
 #include "LRU_FileList.h"
 
-#include "util/Enums.h"
+#include "util/Utils.h"
 
 class Simulation;
 

--- a/src/BandwidthModifier.h
+++ b/src/BandwidthModifier.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2020. <ADD YOUR HEADER INFORMATION>.
+ * Generated with the wrench-init.in tool.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#ifndef MY_BANDWIDTH_MODIFIER_H
+#define MY_BANDWIDTH_MODIFIER_H
+
+#include <wrench-dev.h>
+#include <iostream>
+#include <fstream>
+
+#include "JobSpecification.h"
+#include "LRU_FileList.h"
+
+#include "util/Enums.h"
+
+class Simulation;
+
+class BandwidthModifier : public wrench::ExecutionController {
+public:
+    // Constructor
+    BandwidthModifier(
+              const std::string &hostname,
+              const std::string &link_name,
+              double period,
+              std::normal_distribution<double>* distribution,
+              unsigned long seed);
+
+private:
+
+    std::string link_name;
+    double period;
+    std::normal_distribution<double>* distribution;
+    std::mt19937 generator;
+    unsigned long seed;
+
+    int main() override;
+
+};
+
+#endif //MY_BANDWIDTH_MODIFIER_H
+


### PR DESCRIPTION
This pull request implements a feature for randomly varying the bandwidths of network links in order to be able to approximate the influence of entities outside the simulated platform. Those entities, existent in real systems, might introduce some load on the network, which is part of the simulated system, but don't directly interact with the rest of the platform. Therefore, they manifest only by reducing the available network bandwidths for the simulated system.