### PR TITLE
Extend DCSim with a simplified scheduler module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ include_directories(src/ ${SimGrid_INCLUDE_DIR}/include /usr/local/include /opt/
 set(SOURCE_FILES
         src/WorkloadExecutionController.h
         src/WorkloadExecutionController.cpp
+        src/JobScheduler.h
+        src/JobScheduler.cpp
         src/SimpleSimulator.h
         src/SimpleSimulator.cpp
         src/JobSpecification.h
@@ -40,7 +42,7 @@ set(SOURCE_FILES
         src/computation/StreamedComputation.cpp
         src/computation/CopyComputation.h
         src/computation/CopyComputation.cpp
-        )
+        src/JobScheduler.cpp src/JobScheduler.h)
 
 # test files
 set(TEST_FILES

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.authors="maximilian.horzela@kit.edu"
 
@@ -16,7 +16,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y \
-        cmake python3-full pip gcc make gfortran libboost-all-dev git && \
+        cmake python3 pip gcc make gfortran libboost-all-dev git && \
     apt-get -y autoclean && apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/*
 RUN python3 -m pip install --upgrade --no-input \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y \
-        cmake python3 pip gcc make gfortran libboost-all-dev git && \
+        cmake python3-full pip gcc make gfortran libboost-all-dev git && \
     apt-get -y autoclean && apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/*
 RUN python3 -m pip install --upgrade --no-input \

--- a/src/JobScheduler.cpp
+++ b/src/JobScheduler.cpp
@@ -46,8 +46,7 @@ void JobScheduler::schedule() {
         if (ec->isWorkloadEmpty()) {
             continue; // all jobs have been submitted fo this execution controller
         }
-        std::cerr << "TRYING TO SCHEDULE A JOB FROM EC " << ec->getName() << "\n";
-
+        
         // Loop through all the jobs in the workload in sequence
         std::vector<std::string> scheduled_jobs;
         for (const auto &job_spec: ec->get_workload_spec()) {
@@ -59,12 +58,9 @@ void JobScheduler::schedule() {
                 return;
             }
 
-            std::cerr << "TRYING TO SCHEDULE: " << job_name << " " << num_cores << " " << total_ram << "\n";
-
             auto target_cs = pickComputeService(num_cores, total_ram);
             if (target_cs) {
                 auto job = ec->createAndSubmitJob(job_name, target_cs);
-                std::cerr << "JOB CREATED AND SUBMITTED\n";
                 std::get<0>(this->available_resources[target_cs]) -= num_cores;
                 std::get<1>(this->available_resources[target_cs]) -= total_ram;
                 this->total_num_idle_cores -= num_cores;
@@ -80,7 +76,6 @@ void JobScheduler::schedule() {
 
 std::shared_ptr<wrench::ComputeService> JobScheduler::pickComputeService(unsigned long num_cores, double total_ram) {
     for (auto const &entry: this->available_resources) {
-        std::cerr << "Looking at CS: " << entry.first->getName() << "\n";
         if ((num_cores <= std::get<0>(entry.second)) and
             (total_ram <= std::get<1>(entry.second))) {
                 return entry.first;

--- a/src/JobScheduler.cpp
+++ b/src/JobScheduler.cpp
@@ -49,6 +49,7 @@ void JobScheduler::schedule() {
         std::cerr << "TRYING TO SCHEDULE A JOB FROM EC " << ec->getName() << "\n";
 
         // Loop through all the jobs in the workload in sequence
+        std::vector<std::string> scheduled_jobs;
         for (const auto &job_spec: ec->get_workload_spec()) {
             auto job_name = job_spec.first;
             auto num_cores = job_spec.second.cores;
@@ -60,20 +61,31 @@ void JobScheduler::schedule() {
 
             std::cerr << "TRYING TO SCHEDULE: " << job_name << " " << num_cores << " " << total_ram << "\n";
 
-            for (auto const &entry: this->available_resources) {
-                std::cerr << "Looking at CS: " << entry.first->getName() << "\n";
-                if ((num_cores <= std::get<0>(entry.second)) and
-                    (total_ram <= std::get<1>(entry.second))) {
-                    // Create the job and schedule it
-                    std::cerr << "YES!!\n";
-                    auto job = ec->createAndSubmitJob(job_name, entry.first);
-                    std::cerr << "JOB CREATED AND SUBMITTED\n";
-                    std::get<0>(this->available_resources[entry.first]) -= num_cores;
-                    std::get<1>(this->available_resources[entry.first]) -= total_ram;
-                    this->total_num_idle_cores -= num_cores;
-                    break;
-                }
+            auto target_cs = pickComputeService(num_cores, total_ram);
+            if (target_cs) {
+                auto job = ec->createAndSubmitJob(job_name, target_cs);
+                std::cerr << "JOB CREATED AND SUBMITTED\n";
+                std::get<0>(this->available_resources[target_cs]) -= num_cores;
+                std::get<1>(this->available_resources[target_cs]) -= total_ram;
+                this->total_num_idle_cores -= num_cores;
+                scheduled_jobs.push_back(job_name);
             }
         }
+        // Clear jobs from the workload
+        for (auto const &job_name : scheduled_jobs) {
+            ec->setJobSubmitted(job_name);
+        }
     }
+}
+
+std::shared_ptr<wrench::ComputeService> JobScheduler::pickComputeService(unsigned long num_cores, double total_ram) {
+    for (auto const &entry: this->available_resources) {
+        std::cerr << "Looking at CS: " << entry.first->getName() << "\n";
+        if ((num_cores <= std::get<0>(entry.second)) and
+            (total_ram <= std::get<1>(entry.second))) {
+                return entry.first;
+            break;
+        }
+    }
+    return nullptr;
 }

--- a/src/JobScheduler.cpp
+++ b/src/JobScheduler.cpp
@@ -1,0 +1,74 @@
+
+
+#include "JobScheduler.h"
+#include "WorkloadExecutionController.h"
+
+
+JobScheduler::JobScheduler(const std::vector<std::shared_ptr<wrench::ComputeService>> &compute_services)  {
+    this->compute_services = compute_services;
+    this->total_num_idle_cores = 0;
+
+    // Create view of available resources
+    for (auto const &cs : compute_services) {
+        if (cs->getNumHosts() != 1) {
+            throw std::invalid_argument("JobScheduler::init(): Only 1-host compute services are supported!");
+        }
+        unsigned long num_cores = cs->getPerHostNumCores().begin()->second;
+        double ram = cs->getMemoryCapacity().begin()->second;
+        this->total_num_idle_cores += num_cores;
+
+        this->available_resources[cs] = std::tuple(num_cores, ram);
+    }
+}
+
+void JobScheduler::addExecutionController(WorkloadExecutionController *execution_controller) {
+    this->execution_controllers.push_back(execution_controller);
+}
+
+
+void JobScheduler::jobDone(const std::shared_ptr<wrench::CompoundJob> &job) {
+    // Num cores
+    std::get<0>(this->available_resources[job->getParentComputeService()])++;
+    // RAM
+    // TODO: Check that the RAM is what we think it is
+    std::get<1>(this->available_resources[job->getParentComputeService()]) += job->getMinimumRequiredMemory();
+    this->total_num_idle_cores += job->getMinimumRequiredNumCores();
+}
+
+void JobScheduler::schedule() {
+
+    if (this->total_num_idle_cores == 0) {
+        return;
+    }
+
+    std::cerr << "I AM IN SCHEDULE!\n";
+
+    // Pick a workload in an execution controller
+    std::shared_ptr<WorkloadExecutionController> picked_execution_controller = nullptr;
+    for (auto const &ec: this->execution_controllers) {
+        if (ec->isWorkloadEmpty()) {
+            continue;
+        }
+
+        // Loop through all the jobs in the workload until
+        for (const auto &job_spec: ec->get_workload_spec()) {
+            auto job_name = job_spec.first;
+            auto num_cores = job_spec.second.cores;
+            auto total_ram = job_spec.second.total_mem;
+
+            // TODO: Do this efficiently via priority queues/maps etc,
+            //  stop when for sure nothing can be scheduled etc
+            // Pick a compute services
+            for (auto const &entry: this->available_resources) {
+                if ((num_cores <= std::get<0>(entry.second)) and
+                    (total_ram <= std::get<1>(entry.second))) {
+                    // Create the job and schedule it
+                    auto job = ec->createAndSubmitJob(job_name, entry.first);
+                    std::get<0>(this->available_resources[entry.first]) -= num_cores;
+                    std::get<1>(this->available_resources[entry.first]) -= total_ram;
+                    this->total_num_idle_cores -= num_cores;
+                }
+            }
+        }
+    }
+}

--- a/src/JobScheduler.cpp
+++ b/src/JobScheduler.cpp
@@ -38,7 +38,7 @@ void JobScheduler::addExecutionController(WorkloadExecutionController *execution
  */
 void JobScheduler::jobDone(const std::shared_ptr<wrench::CompoundJob> &job) {
     // Num cores
-    std::get<0>(this->available_resources[job->getParentComputeService()])++;
+    std::get<0>(this->available_resources[job->getParentComputeService()]) += job->getMinimumRequiredNumCores();
     // RAM   TODO: Check that the RAM is what we think it is
     std::get<1>(this->available_resources[job->getParentComputeService()]) += job->getMinimumRequiredMemory();
     this->total_num_idle_cores += job->getMinimumRequiredNumCores();
@@ -55,6 +55,7 @@ void JobScheduler::schedule() {
 
     // Go through the workload execution controllers in order
     for (auto const &ec: this->execution_controllers) {
+        // TODO: Remove the execution controller from the list
         if (ec->isWorkloadEmpty()) {
             continue; // all jobs have been submitted fo this execution controller
         }
@@ -70,7 +71,7 @@ void JobScheduler::schedule() {
                 return;
             }
 
-            // See if there is an compute service that can accommodate the job
+            // See if there is a compute service that can accommodate the job
             auto target_cs = pickComputeService(num_cores, total_ram);
             if (target_cs) {
                 ec->createAndSubmitJob(job_name, target_cs);

--- a/src/JobScheduler.cpp
+++ b/src/JobScheduler.cpp
@@ -3,12 +3,15 @@
 #include "JobScheduler.h"
 #include "WorkloadExecutionController.h"
 
-
+/**
+ * @brief Constructor
+ * @param compute_services: the set of compute services that this job scheduler will submit jobs to
+ */
 JobScheduler::JobScheduler(const std::vector<std::shared_ptr<wrench::ComputeService>> &compute_services)  {
-    this->compute_services = compute_services;
     this->total_num_idle_cores = 0;
 
-    // Create view of available resources
+    // Create view of available resources as a map of compute services
+    // to core and ram availability
     for (auto const &cs : compute_services) {
         if (cs->getNumHosts() != 1) {
             throw std::invalid_argument("JobScheduler::init(): Only 1-host compute services are supported!");
@@ -21,20 +24,29 @@ JobScheduler::JobScheduler(const std::vector<std::shared_ptr<wrench::ComputeServ
     }
 }
 
+/**
+ * @brief A a new execution controller that has a workload that this job scheduler should handle
+ * @param execution_controller
+ */
 void JobScheduler::addExecutionController(WorkloadExecutionController *execution_controller) {
     this->execution_controllers.push_back(execution_controller);
 }
 
-
+/**
+ * @brief A method to notify the scheduler that a job has completed
+ * @param job
+ */
 void JobScheduler::jobDone(const std::shared_ptr<wrench::CompoundJob> &job) {
     // Num cores
     std::get<0>(this->available_resources[job->getParentComputeService()])++;
-    // RAM
-    // TODO: Check that the RAM is what we think it is
+    // RAM   TODO: Check that the RAM is what we think it is
     std::get<1>(this->available_resources[job->getParentComputeService()]) += job->getMinimumRequiredMemory();
     this->total_num_idle_cores += job->getMinimumRequiredNumCores();
 }
 
+/**
+ * @brief A method that should be invoked whenever there may be schedulable jobs
+ */
 void JobScheduler::schedule() {
 
     if (this->total_num_idle_cores == 0) {
@@ -46,7 +58,7 @@ void JobScheduler::schedule() {
         if (ec->isWorkloadEmpty()) {
             continue; // all jobs have been submitted fo this execution controller
         }
-        
+
         // Loop through all the jobs in the workload in sequence
         std::vector<std::string> scheduled_jobs;
         for (const auto &job_spec: ec->get_workload_spec()) {
@@ -58,15 +70,17 @@ void JobScheduler::schedule() {
                 return;
             }
 
+            // See if there is an compute service that can accommodate the job
             auto target_cs = pickComputeService(num_cores, total_ram);
             if (target_cs) {
-                auto job = ec->createAndSubmitJob(job_name, target_cs);
+                ec->createAndSubmitJob(job_name, target_cs);
                 std::get<0>(this->available_resources[target_cs]) -= num_cores;
                 std::get<1>(this->available_resources[target_cs]) -= total_ram;
                 this->total_num_idle_cores -= num_cores;
                 scheduled_jobs.push_back(job_name);
             }
         }
+
         // Clear jobs from the workload
         for (auto const &job_name : scheduled_jobs) {
             ec->setJobSubmitted(job_name);
@@ -74,12 +88,19 @@ void JobScheduler::schedule() {
     }
 }
 
+/**
+ * @brief Find a compute service with sufficient available resources
+ * @param num_cores: the needed number of cores
+ * @param total_ram: the needed RAM footprint
+ * @return a compute service
+ */
 std::shared_ptr<wrench::ComputeService> JobScheduler::pickComputeService(unsigned long num_cores, double total_ram) {
+    // Just a linear search right now, picking the first
+    // compute service that works
     for (auto const &entry: this->available_resources) {
         if ((num_cores <= std::get<0>(entry.second)) and
             (total_ram <= std::get<1>(entry.second))) {
-                return entry.first;
-            break;
+            return entry.first;
         }
     }
     return nullptr;

--- a/src/JobScheduler.h
+++ b/src/JobScheduler.h
@@ -1,0 +1,31 @@
+
+
+#ifndef DCSIM_JOBSCHEDULER_H
+#define DCSIM_JOBSCHEDULER_H
+
+#include <wrench-dev.h>
+#include <iostream>
+#include <vector>
+
+class WorkloadExecutionController;
+
+class JobScheduler {
+
+public:
+
+
+    JobScheduler(const std::vector<std::shared_ptr<wrench::ComputeService>> &compute_services);
+    void addExecutionController(WorkloadExecutionController *execution_controller);
+    void schedule();
+    void jobDone(const std::shared_ptr<wrench::CompoundJob> &job);
+    
+private:
+    std::map<std::shared_ptr<wrench::ComputeService>, std::tuple<unsigned long, double>> available_resources;
+    std::vector<std::shared_ptr<wrench::ComputeService>> compute_services;
+    std::vector<WorkloadExecutionController *> execution_controllers;
+    unsigned long total_num_idle_cores;
+
+};
+
+
+#endif //DCSIM_JOBSCHEDULER_H

--- a/src/JobScheduler.h
+++ b/src/JobScheduler.h
@@ -25,7 +25,10 @@ private:
     std::vector<WorkloadExecutionController *> execution_controllers;
     unsigned long total_num_idle_cores;
 
-};
+    std::shared_ptr<wrench::ComputeService> pickComputeService(unsigned long num_cores, double total_ram);
+
+
+    };
 
 
 #endif //DCSIM_JOBSCHEDULER_H

--- a/src/JobScheduler.h
+++ b/src/JobScheduler.h
@@ -13,22 +13,18 @@ class JobScheduler {
 
 public:
 
-
-    JobScheduler(const std::vector<std::shared_ptr<wrench::ComputeService>> &compute_services);
+    explicit JobScheduler(const std::vector<std::shared_ptr<wrench::ComputeService>> &compute_services);
     void addExecutionController(WorkloadExecutionController *execution_controller);
     void schedule();
     void jobDone(const std::shared_ptr<wrench::CompoundJob> &job);
-    
+
 private:
     std::map<std::shared_ptr<wrench::ComputeService>, std::tuple<unsigned long, double>> available_resources;
-    std::vector<std::shared_ptr<wrench::ComputeService>> compute_services;
     std::vector<WorkloadExecutionController *> execution_controllers;
     unsigned long total_num_idle_cores;
 
     std::shared_ptr<wrench::ComputeService> pickComputeService(unsigned long num_cores, double total_ram);
 
-
-    };
-
+};
 
 #endif //DCSIM_JOBSCHEDULER_H

--- a/src/SimpleSimulator.cpp
+++ b/src/SimpleSimulator.cpp
@@ -619,7 +619,7 @@ int main(int argc, char **argv) {
 
     // Create a list of cache storage services
     std::set<std::shared_ptr<wrench::StorageService>> cache_storage_services;
-    for (auto host: SimpleSimulator::cache_hosts) {
+    for (auto const &host: SimpleSimulator::cache_hosts) {
         //TODO: Support more than one type of cache mounted differently?
         //TODO: This might not be necessary since different cache layers are typically on different hosts
         auto storage_service = simulation->add(
@@ -633,7 +633,7 @@ int main(int argc, char **argv) {
     // and remote storages that are able to serve all file requests
 
     std::set<std::shared_ptr<wrench::StorageService>> grid_storage_services;
-    for (auto host: SimpleSimulator::storage_hosts) {
+    for (auto const &host: SimpleSimulator::storage_hosts) {
         auto storage_service = simulation->add(
                 wrench::SimpleStorageService::createSimpleStorageService(
                         host, {"/"},
@@ -714,7 +714,6 @@ int main(int argc, char **argv) {
         }
         std::cerr << "Total number of execution controllers: " << workload_execution_controllers.size() << "\n";
     }
-
 
 
     /* Instantiate inputfiles and set outfile destinations*/

--- a/src/WorkloadExecutionController.cpp
+++ b/src/WorkloadExecutionController.cpp
@@ -65,7 +65,6 @@ WorkloadExecutionController::WorkloadExecutionController(
  */
 std::shared_ptr<wrench::CompoundJob> WorkloadExecutionController::createAndSubmitJob(const std::string &job_name,
                                                                                      const std::shared_ptr<wrench::ComputeService> &cs) {
-    // Pick the first job
     auto job_spec = this->workload_spec[job_name];
     auto job = job_manager->createCompoundJob(job_name);
 
@@ -266,7 +265,6 @@ WorkloadExecutionController::processEventCompoundJobFailure(std::shared_ptr<wren
 */
 void WorkloadExecutionController::processEventCompoundJobCompletion(
         std::shared_ptr<wrench::CompoundJobCompletedEvent> event) {
-
 
     this->job_scheduler->jobDone(event->job);
     this->num_completed_jobs++;

--- a/src/WorkloadExecutionController.cpp
+++ b/src/WorkloadExecutionController.cpp
@@ -149,7 +149,10 @@ std::shared_ptr<wrench::CompoundJob> WorkloadExecutionController::createAndSubmi
         job->addActionDependency(compute_action, fw_action);
     }
 
+    std::cerr << "SUBMITTING THE JOB\n";
+
     // Submit the job
+    WRENCH_INFO("Submitting job %s to compute service %s...", job->getName().c_str(), cs->getName().c_str());
    job_manager->submitJob(job, cs);
 
     // Remove it form the workload spec

--- a/src/WorkloadExecutionController.cpp
+++ b/src/WorkloadExecutionController.cpp
@@ -154,12 +154,14 @@ std::shared_ptr<wrench::CompoundJob> WorkloadExecutionController::createAndSubmi
     // Submit the job
     WRENCH_INFO("Submitting job %s to compute service %s...", job->getName().c_str(), cs->getName().c_str());
    job_manager->submitJob(job, cs);
+    return job;
+}
 
+
+void WorkloadExecutionController::setJobSubmitted(const std::string &job_name) {
     // Remove it form the workload spec
     this->workload_spec_submitted[job_name] = this->workload_spec[job_name];
     this->workload_spec.erase(job_name);
-
-    return job;
 }
 
 

--- a/src/WorkloadExecutionController.h
+++ b/src/WorkloadExecutionController.h
@@ -44,12 +44,10 @@ public:
         this->workload_spec = std::move(w);
     }
 
-    void setJobScheduler(const std::shared_ptr<JobScheduler> &job_scheduler) {
-        this->job_scheduler = job_scheduler;
-    }
-
     std::shared_ptr<wrench::CompoundJob> createAndSubmitJob(const std::string &job_name,
                                                             const std::shared_ptr<wrench::ComputeService> &cs);
+    void setJobSubmitted(const std::string &job_name);
+
     bool isWorkloadEmpty();
 
 protected:

--- a/src/WorkloadExecutionController.h
+++ b/src/WorkloadExecutionController.h
@@ -58,6 +58,7 @@ protected:
 
 private:
     std::map<std::string, JobSpecification> workload_spec;
+    std::map<std::string, JobSpecification> workload_spec_submitted;
     std::shared_ptr<JobScheduler> job_scheduler;
 
     std::set<std::shared_ptr<wrench::StorageService>> grid_storage_services;

--- a/src/WorkloadExecutionController.h
+++ b/src/WorkloadExecutionController.h
@@ -7,8 +7,8 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  */
-#ifndef MY_SIMPLE_EXECUTION_CONTROLLER_H
-#define MY_SIMPLE_EXECUTION_CONTROLLER_H
+#ifndef DCSIM_WORKLOAD_EXECUTION_CONTROLLER_H
+#define DCSIM_WORKLOAD_EXECUTION_CONTROLLER_H
 
 #include <wrench-dev.h>
 #include <iostream>
@@ -16,6 +16,7 @@
 #include <utility>
 
 #include "JobSpecification.h"
+#include "JobScheduler.h"
 #include "Workload.h"
 #include "LRU_FileList.h"
 
@@ -28,7 +29,7 @@ public:
     // Constructor
     WorkloadExecutionController(
             const Workload &workload_spec,
-            const std::set<std::shared_ptr<wrench::HTCondorComputeService>> &htcondor_compute_services,
+            const std::shared_ptr<JobScheduler> &job_scheduler,
             const std::set<std::shared_ptr<wrench::StorageService>> &grid_storage_services,
             const std::set<std::shared_ptr<wrench::StorageService>> &cache_storage_services,
             const std::string &hostname,
@@ -43,23 +44,31 @@ public:
         this->workload_spec = std::move(w);
     }
 
+    void setJobScheduler(const std::shared_ptr<JobScheduler> &job_scheduler) {
+        this->job_scheduler = job_scheduler;
+    }
+
+    std::shared_ptr<wrench::CompoundJob> createAndSubmitJob(const std::string &job_name,
+                                                            const std::shared_ptr<wrench::ComputeService> &cs);
+    bool isWorkloadEmpty();
 
 protected:
     void processEventCompoundJobFailure(std::shared_ptr<wrench::CompoundJobFailedEvent>) override;
     void processEventCompoundJobCompletion(std::shared_ptr<wrench::CompoundJobCompletedEvent>) override;
 
 private:
-    std::set<std::shared_ptr<wrench::HTCondorComputeService>> htcondor_compute_services;
+    std::map<std::string, JobSpecification> workload_spec;
+    std::shared_ptr<JobScheduler> job_scheduler;
+
     std::set<std::shared_ptr<wrench::StorageService>> grid_storage_services;
     std::set<std::shared_ptr<wrench::StorageService>> cache_storage_services;
 
-    /** @brief job batch to submit with all specs **/
-    std::map<std::string, JobSpecification> workload_spec;
 
-    std::shared_ptr<wrench::CompoundJob> createJob(const std::string& job_name);
-    unsigned long submitBatchOfJobs(const std::shared_ptr<wrench::HTCondorComputeService>& htcondor_compute_service,
-                                    std::vector<const std::string *> job_spec_keys,
-                                    size_t batch_index, size_t batch_size);
+
+//
+//    unsigned long submitBatchOfJobs(const std::shared_ptr<wrench::HTCondorComputeService>& htcondor_compute_service,
+//                                    std::vector<const std::string *> job_spec_keys,
+//                                    size_t batch_index, size_t batch_size);
 
 
     int main() override;
@@ -100,4 +109,4 @@ private:
     std::mt19937 generator;
 };
 
-#endif//MY_SIMPLE_EXECUTION_CONTROLLER_H
+#endif//DCSIM_WORKLOAD_EXECUTION_CONTROLLER_H

--- a/src/WorkloadExecutionController.h
+++ b/src/WorkloadExecutionController.h
@@ -62,14 +62,6 @@ private:
     std::set<std::shared_ptr<wrench::StorageService>> grid_storage_services;
     std::set<std::shared_ptr<wrench::StorageService>> cache_storage_services;
 
-
-
-//
-//    unsigned long submitBatchOfJobs(const std::shared_ptr<wrench::HTCondorComputeService>& htcondor_compute_service,
-//                                    std::vector<const std::string *> job_spec_keys,
-//                                    size_t batch_index, size_t batch_size);
-
-
     int main() override;
 
     /** @brief The job manager */

--- a/tools/run_benchmark.sh
+++ b/tools/run_benchmark.sh
@@ -1,34 +1,59 @@
-if [ ! $# -eq 4 ]; then
-    echo "Usage: ${0} <# of jobs> <# of files per job> <xrootd block size> <buffer size>"
-    exit 1
+#! /bin/bash
+
+# script for execution of simulation scenarios to test the runtime and memory scaling of the simulator
+#
+#
+parent="$( dirname "$base" )"
+PLATFORM1="$parent/data/platform-files/WLCG_disklessTier2.xml"
+PLATFORM2="$parent/data/platform-files/WLCG_disklessTier2_Tier1_MODIFIED.xml"
+PLATFORM3="$parent/data/platform-files/WLCG_disklessTier2_Tier1_Tier2_MODIFIED.xml"
+WORKLOAD="$parent/data/workload-configs/simScaling.json"
+DATASET="$parent/data/dataset-configs/simScaling.json"
+DUPLICATIONS=1
+HITRATE=0.0
+XRDBLOCKSIZE=1000000000
+
+SCENARIO="wlcg"
+#BUFFER_SIZE=0
+BUFFER_SIZE=0
+
+if [ ! -d "tmp/monitor/$SCENARIO" ]; then
+    mkdir -p tmp/monitor/$SCENARIO
 fi
 
 
-NJOBS="${1}"
-NINFILES="${2}"
-XRDBLOCKSIZE="${3}"
-BUFFERSIZE="${4}"
-AVGINSIZE=$(bc -l <<< "8554379000/20")
-SIGMAINSIZE=$(bc -l <<< "10000")
-FLOPS=$(bc -l <<< "1.95*1480*1000*1000*1000")
-SIGMAFLOPS=10000000
-MEM=2400
-OUTSIZE=$(bc -l <<< "50000000")
-SIGMAOUTSIZE=$(bc -l <<< "1000000")
-DUPLICATIONS=1
-HITRATE=0.05
-
-
-PLATFORM="../data/platform-files/ETPbatch_faster"
-
-LD_PRELOAD=/usr/local/lib/libprofiler.so CPUPROFILE=prof_${NJOBS}_${XRDBLOCKSIZE}_${BUFFERSIZE}.out ./dc-sim --platform ${PLATFORM}.xml \
-        --njobs ${NJOBS} --ninfiles ${NINFILES} --insize ${AVGINSIZE} --sigma-insize ${SIGMAINSIZE} \
-        --flops ${FLOPS} --sigma-flops ${SIGMAFLOPS} --mem ${MEM} \
-        --outsize ${OUTSIZE} --sigma-outsize ${SIGMAOUTSIZE} \
-        --duplications ${DUPLICATIONS} \
-        --hitrate 0.0 \
- 	--storage-buffer-size ${BUFFERSIZE} \
-        --xrd-blocksize ${XRDBLOCKSIZE} \
-        --output-file ${PLATFORM}${NJOBS}.csv 
-
-pprof --text `pwd`/dc-sim prof_${NJOBS}_${XRDBLOCKSIZE}_${BUFFERSIZE}.out > prof_${NJOBS}_${XRDBLOCKSIZE}_${BUFFERSIZE}.txt
+for NJOBS in 400
+do
+    for XRDBLOCKSIZE in 1000000000
+    do
+	for PLATFORM in $PLATFORM1
+	do
+		echo "PLATFORM: $PLATFORM"
+		PLATFORM_NAME=`echo $PLATFORM | sed "s/.*\///"`
+    		WORKLOAD_TMP="${WORKLOAD}.tmp" 
+    		cp $WORKLOAD $WORKLOAD_TMP
+    		DATASET_TMP="${DATASET}.tmp"
+    		cp $DATASET $DATASET_TMP
+    		NFILES=$((NJOBS*20))
+    		sed -i "" "s/\"num_jobs\": [0-9]*,/\"num_jobs\": $NJOBS,/" "$WORKLOAD_TMP"
+    		sed -i "" "s/\"num_files\": [0-9]*,/\"num_files\": $NFILES,/" "$DATASET_TMP"
+		OUTFILE=/tmp/benchmark_xrtd_$PLATFORM_NAME.stdout
+		ERRFILE=/tmp/benchmark_xrtd_$PLATFORM_NAME.stderr
+    		/opt/local/bin/gtime -v dc-sim --platform "$PLATFORM" \
+        		--duplications ${DUPLICATIONS} \
+        		--hitrate 1.0 \
+			--storage-buffer-size $BUFFER_SIZE \
+			--wrench-commport-pool-size=100000 \
+        		--xrd-blocksize ${XRDBLOCKSIZE} \
+        		--output-file /dev/null \
+        		--wrench-full-log \
+        		--workload-configurations "$WORKLOAD_TMP" \
+        			--dataset-configurations "$DATASET_TMP"  1> $OUTFILE 2> $ERRFILE
+    		cat $ERRFILE | grep -e "done" | sed "s/S.* /$NJOBS jobs took /" | sed "s/$/ sec/"
+    		cat $ERRFILE | grep -e "Elap" | sed "s/.*):/  - Elapsed:    /"
+    		cat $ERRFILE | grep -e "Maxi" | sed "s/.*):/  - MaxRSS (kb):/"
+		echo "Detailed RSS info: cat $ERRFILE | grep CURRENT"
+   
+		done
+	done
+done

--- a/tools/run_benchmark.sh
+++ b/tools/run_benchmark.sh
@@ -4,25 +4,17 @@
 #
 #
 parent="$( dirname "$base" )"
-PLATFORM1="$parent/data/platform-files/WLCG_disklessTier2.xml"
-PLATFORM2="$parent/data/platform-files/WLCG_disklessTier2_Tier1_MODIFIED.xml"
-PLATFORM3="$parent/data/platform-files/WLCG_disklessTier2_Tier1_Tier2_MODIFIED.xml"
-WORKLOAD="$parent/data/workload-configs/simScaling.json"
-DATASET="$parent/data/dataset-configs/simScaling.json"
+PLATFORM1="$parent/data/platform-files/sgbatch_validation.xml"
+WORKLOAD="$parent/data/workload-configs/crown_ttbar_testjob.json"
+DATASET="$parent/data/dataset-configs/crown_ttbar_testjob.json"
 DUPLICATIONS=1
 HITRATE=0.0
 XRDBLOCKSIZE=1000000000
 
-SCENARIO="wlcg"
-#BUFFER_SIZE=0
 BUFFER_SIZE=0
 
-if [ ! -d "tmp/monitor/$SCENARIO" ]; then
-    mkdir -p tmp/monitor/$SCENARIO
-fi
 
-
-for NJOBS in 100
+for NJOBS in 800
 do
     for XRDBLOCKSIZE in 1000000000
     do

--- a/tools/run_benchmark.sh
+++ b/tools/run_benchmark.sh
@@ -22,7 +22,7 @@ if [ ! -d "tmp/monitor/$SCENARIO" ]; then
 fi
 
 
-for NJOBS in 400
+for NJOBS in 100
 do
     for XRDBLOCKSIZE in 1000000000
     do

--- a/tools/run_benchmark.sh
+++ b/tools/run_benchmark.sh
@@ -14,7 +14,7 @@ XRDBLOCKSIZE=1000000000
 BUFFER_SIZE=0
 
 
-for NJOBS in 800
+for NJOBS in 8000
 do
     for XRDBLOCKSIZE in 1000000000
     do
@@ -22,13 +22,13 @@ do
 	do
 		echo "PLATFORM: $PLATFORM"
 		PLATFORM_NAME=`echo $PLATFORM | sed "s/.*\///"`
-    		WORKLOAD_TMP="${WORKLOAD}.tmp" 
-    		cp $WORKLOAD $WORKLOAD_TMP
-    		DATASET_TMP="${DATASET}.tmp"
-    		cp $DATASET $DATASET_TMP
-    		NFILES=$((NJOBS*20))
-    		sed -i "" "s/\"num_jobs\": [0-9]*,/\"num_jobs\": $NJOBS,/" "$WORKLOAD_TMP"
-    		sed -i "" "s/\"num_files\": [0-9]*,/\"num_files\": $NFILES,/" "$DATASET_TMP"
+    		#WORKLOAD_TMP="${WORKLOAD}.tmp" 
+    		#cp $WORKLOAD $WORKLOAD_TMP
+    		#DATASET_TMP="${DATASET}.tmp"
+    		#cp $DATASET $DATASET_TMP
+    		#NFILES=$((NJOBS*20))
+    		#sed -i "" "s/\"num_jobs\": [0-9]*,/\"num_jobs\": $NJOBS,/" "$WORKLOAD_TMP"
+    		#sed -i "" "s/\"num_files\": [0-9]*,/\"num_files\": $NFILES,/" "$DATASET_TMP"
 		OUTFILE=/tmp/benchmark_xrtd_$PLATFORM_NAME.stdout
 		ERRFILE=/tmp/benchmark_xrtd_$PLATFORM_NAME.stderr
     		/opt/local/bin/gtime -v dc-sim --platform "$PLATFORM" \
@@ -39,8 +39,8 @@ do
         		--xrd-blocksize ${XRDBLOCKSIZE} \
         		--output-file /dev/null \
         		--wrench-full-log \
-        		--workload-configurations "$WORKLOAD_TMP" \
-        			--dataset-configurations "$DATASET_TMP"  1> $OUTFILE 2> $ERRFILE
+        		--workload-configurations "$WORKLOAD" \
+        			--dataset-configurations "$DATASET"  1> $OUTFILE 2> $ERRFILE
     		cat $ERRFILE | grep -e "done" | sed "s/S.* /$NJOBS jobs took /" | sed "s/$/ sec/"
     		cat $ERRFILE | grep -e "Elap" | sed "s/.*):/  - Elapsed:    /"
     		cat $ERRFILE | grep -e "Maxi" | sed "s/.*):/  - MaxRSS (kb):/"


### PR DESCRIPTION
This PR implements a scheduler class that replicates the functionality of the [`wrench/HTCondorComputeService`](https://github.com/wrench-project/wrench/tree/master/src/wrench/services/compute/htcondor) to implement an HTCondor-ish scheduler that takes CPU and Memory requirements into account. HTCondor messages and overheads are not simulated, since they introduce a measurable impact on simulation time while being negligible for most simulated executions in the DCSim context. Instead, only the scheduling decision-making is replicated to assign jobs to resources without realistically simulating this process in real systems.
 
Additionally, the scheduler loads only as many simulated job entities into memory as needed to fill the platform at any given time. This reduces the maximum memory footprint of the simulator significantly.

This scheduler class can be used as a base class for implementing schedulers with extended job and machine requirements. 

