### PR TITLE
Method signature fixes

### DIFF
--- a/src/WorkloadExecutionController.cpp
+++ b/src/WorkloadExecutionController.cpp
@@ -248,7 +248,7 @@ int WorkloadExecutionController::main() {
  * @param event: an execution event
  */
 void
-WorkloadExecutionController::processEventCompoundJobFailure(std::shared_ptr<wrench::CompoundJobFailedEvent> event) {
+WorkloadExecutionController::processEventCompoundJobFailure(const std::shared_ptr<wrench::CompoundJobFailedEvent> &event) {
     WRENCH_INFO("Notified that compound job %s has failed!", event->job->getName().c_str());
     WRENCH_INFO("Failure cause: %s", event->failure_cause->toString().c_str());
     WRENCH_INFO("As a WorkloadExecutionController, I abort as soon as there is a failure");
@@ -264,7 +264,7 @@ WorkloadExecutionController::processEventCompoundJobFailure(std::shared_ptr<wren
 * @param event: an execution event
 */
 void WorkloadExecutionController::processEventCompoundJobCompletion(
-        std::shared_ptr<wrench::CompoundJobCompletedEvent> event) {
+        const std::shared_ptr<wrench::CompoundJobCompletedEvent> &event) {
 
     this->job_scheduler->jobDone(event->job);
     this->num_completed_jobs++;

--- a/src/WorkloadExecutionController.h
+++ b/src/WorkloadExecutionController.h
@@ -51,8 +51,8 @@ public:
     bool isWorkloadEmpty();
 
 protected:
-    void processEventCompoundJobFailure(std::shared_ptr<wrench::CompoundJobFailedEvent>);
-    void processEventCompoundJobCompletion(std::shared_ptr<wrench::CompoundJobCompletedEvent>);
+    void processEventCompoundJobFailure(const std::shared_ptr<wrench::CompoundJobFailedEvent>& event) override;
+    void processEventCompoundJobCompletion(const std::shared_ptr<wrench::CompoundJobCompletedEvent>& event) override;
 
 private:
     std::map<std::string, JobSpecification> workload_spec;


### PR DESCRIPTION
Fixed the processEventCompoundJobFailure() and processEventCompoundJobCompletion() method signatures so that they actually override the base class's methods (i.e., they take a const ref to a shared pointer to an event, rather than just a shared pointer). Also added the override keyword to those methods so that if the base class method signatures ever change again, the compiler will throw an error. 