### PR TITLE
Updated all memory and file sizes to the sg_size_t (instead of double) to match the current WRENCH/SimGrid APIs

### DIFF
--- a/src/Dataset.h
+++ b/src/Dataset.h
@@ -9,7 +9,7 @@ class Dataset {
 public:
     // Constructor
     Dataset(
-            const std::vector<std::string> &hostname,
+            const std::vector<std::string> &hostnames,
             size_t num_files,
             const nlohmann::json &file_size,
             const std::string &name_suffix,

--- a/src/Dataset.h
+++ b/src/Dataset.h
@@ -9,9 +9,10 @@ class Dataset {
 public:
     // Constructor
     Dataset(
-            const std::vector<std::string> hostname, const double num_files,
-            nlohmann::json file_size,
-            const std::string name_suffix,
+            const std::vector<std::string> &hostname,
+            size_t num_files,
+            const nlohmann::json &file_size,
+            const std::string &name_suffix,
             const std::mt19937 &generator);
     std::vector<std::string> hostnames;
     std::vector<std::shared_ptr<wrench::DataFile>> files;
@@ -19,7 +20,7 @@ public:
 
 private:
     std::function<double(std::mt19937 &)> size_dist;
-    std::function<double(std::mt19937 &)> initializeRNG(nlohmann::json json);
+    static std::function<double(std::mt19937 &)> createRNG(nlohmann::json json);
     std::mt19937 generator;
 };
 

--- a/src/JobScheduler.cpp
+++ b/src/JobScheduler.cpp
@@ -17,7 +17,7 @@ JobScheduler::JobScheduler(const std::vector<std::shared_ptr<wrench::ComputeServ
             throw std::invalid_argument("JobScheduler::init(): Only 1-host compute services are supported!");
         }
         unsigned long num_cores = cs->getPerHostNumCores().begin()->second;
-        double ram = cs->getPerHostMemoryCapacity().begin()->second;
+        sg_size_t ram = cs->getPerHostMemoryCapacity().begin()->second;
         this->total_num_idle_cores += num_cores;
 
         this->available_resources[cs] = std::tuple(num_cores, ram);
@@ -95,7 +95,7 @@ void JobScheduler::schedule() {
  * @param total_ram: the needed RAM footprint
  * @return a compute service
  */
-std::shared_ptr<wrench::ComputeService> JobScheduler::pickComputeService(unsigned long num_cores, double total_ram) {
+std::shared_ptr<wrench::ComputeService> JobScheduler::pickComputeService(unsigned long num_cores, sg_size_t total_ram) {
     // Just a linear search right now, picking the first
     // compute service that works
     for (auto const &entry: this->available_resources) {

--- a/src/JobScheduler.cpp
+++ b/src/JobScheduler.cpp
@@ -95,7 +95,7 @@ void JobScheduler::schedule() {
  * @param total_ram: the needed RAM footprint
  * @return a compute service
  */
-std::shared_ptr<wrench::ComputeService> JobScheduler::pickComputeService(unsigned long num_cores, sg_size_t total_ram) {
+std::shared_ptr<wrench::ComputeService> JobScheduler::pickComputeService(const unsigned long num_cores, const sg_size_t total_ram) const {
     // Just a linear search right now, picking the first
     // compute service that works
     for (auto const &entry: this->available_resources) {

--- a/src/JobScheduler.h
+++ b/src/JobScheduler.h
@@ -19,11 +19,11 @@ public:
     void jobDone(const std::shared_ptr<wrench::CompoundJob> &job);
 
 private:
-    std::map<std::shared_ptr<wrench::ComputeService>, std::tuple<unsigned long, double>> available_resources;
+    std::map<std::shared_ptr<wrench::ComputeService>, std::tuple<unsigned long, sg_size_t>> available_resources;
     std::vector<WorkloadExecutionController *> execution_controllers;
     unsigned long total_num_idle_cores;
 
-    std::shared_ptr<wrench::ComputeService> pickComputeService(unsigned long num_cores, double total_ram);
+    std::shared_ptr<wrench::ComputeService> pickComputeService(unsigned long num_cores, sg_size_t total_ram);
 
 };
 

--- a/src/JobScheduler.h
+++ b/src/JobScheduler.h
@@ -23,7 +23,7 @@ private:
     std::vector<WorkloadExecutionController *> execution_controllers;
     unsigned long total_num_idle_cores;
 
-    std::shared_ptr<wrench::ComputeService> pickComputeService(unsigned long num_cores, sg_size_t total_ram);
+    std::shared_ptr<wrench::ComputeService> pickComputeService(unsigned long num_cores, sg_size_t total_ram) const;
 
 };
 

--- a/src/JobSpecification.h
+++ b/src/JobSpecification.h
@@ -26,7 +26,7 @@ public:
     // Total number of FLOPS to be computed for the job to finish
     double total_flops;
     // Memory consumption of the job
-    double total_mem;
+    sg_size_t total_mem;
 };
 
 #endif//S_JOB_SPECIFICATION_H

--- a/src/LRU_FileList.h
+++ b/src/LRU_FileList.h
@@ -46,7 +46,7 @@ public:
      * @param file : a data file
      * @return true if the file is there, false otherwise
      */
-    bool hasFile(std::shared_ptr<wrench::DataFile> file) {
+    bool hasFile(const std::shared_ptr<wrench::DataFile> &file) {
         return (this->indexed_files.find(file.get()) != this->indexed_files.end());
     }
 

--- a/src/MonitorAction.cpp
+++ b/src/MonitorAction.cpp
@@ -5,12 +5,12 @@
  */
 MonitorAction::MonitorAction(
         const std::string &name,
-        double ram,
+        sg_size_t ram,
         unsigned long num_cores,
         const std::function<void(std::shared_ptr<wrench::ActionExecutor> action_executor)> &lambda_execute,
         const std::function<void(std::shared_ptr<wrench::ActionExecutor> action_executor)> &lambda_terminate) : CustomAction(name, ram, num_cores,
-                                                                                                                             std::move(lambda_execute),
-                                                                                                                             std::move(lambda_terminate)) {
+                                                                                                                             lambda_execute,
+                                                                                                                             lambda_terminate) {
     this->calculation_time = DefaultValues::UndefinedDouble;
     this->infile_transfer_time = DefaultValues::UndefinedDouble;
     // this->outfile_transfer_time = 0.;

--- a/src/MonitorAction.cpp
+++ b/src/MonitorAction.cpp
@@ -5,8 +5,8 @@
  */
 MonitorAction::MonitorAction(
         const std::string &name,
-        sg_size_t ram,
-        unsigned long num_cores,
+        const sg_size_t ram,
+        const unsigned long num_cores,
         const std::function<void(std::shared_ptr<wrench::ActionExecutor> action_executor)> &lambda_execute,
         const std::function<void(std::shared_ptr<wrench::ActionExecutor> action_executor)> &lambda_terminate) : CustomAction(name, ram, num_cores,
                                                                                                                              lambda_execute,

--- a/src/MonitorAction.h
+++ b/src/MonitorAction.h
@@ -16,7 +16,7 @@ public:
      */
     MonitorAction(
             const std::string &name,
-            double ram,
+            sg_size_t ram,
             unsigned long num_cores,
             const std::function<void(std::shared_ptr<wrench::ActionExecutor> action_executor)> &lambda_execute,
             const std::function<void(std::shared_ptr<wrench::ActionExecutor> action_executor)> &lambda_terminate);

--- a/src/MonitorAction.h
+++ b/src/MonitorAction.h
@@ -21,29 +21,29 @@ public:
             const std::function<void(std::shared_ptr<wrench::ActionExecutor> action_executor)> &lambda_execute,
             const std::function<void(std::shared_ptr<wrench::ActionExecutor> action_executor)> &lambda_terminate);
 
-    double get_infile_transfer_time() {
+    double get_infile_transfer_time() const {
         return infile_transfer_time;
     }
-    double get_calculation_time() {
+    double get_calculation_time() const {
         return calculation_time;
     }
     // double get_outfile_transfer_time() {
     //     return outfile_transfer_time;
     // }
-    double get_hitrate() {
+    double get_hitrate() const {
         return hitrate;
     }
 
-    void set_infile_transfer_time(double value) {
+    void set_infile_transfer_time(const double value) {
         this->infile_transfer_time = value;
     }
-    void set_calculation_time(double value) {
+    void set_calculation_time(const double value) {
         this->calculation_time = value;
     }
     // void set_outfile_transfer_time(double value) {
     //     this->outfile_transfer_time = value;
     // }
-    void set_hitrate(double value) {
+    void set_hitrate(const double value) {
         this->hitrate = value;
     }
 
@@ -61,4 +61,4 @@ protected:
     double hitrate;
 };
 
-#endif//MY_SIMPLE_EXECUTION_CONTROLLER_H
+#endif//MY_CACHE_COMPUTE_ACTION_H

--- a/src/SimpleSimulator.cpp
+++ b/src/SimpleSimulator.cpp
@@ -46,13 +46,13 @@ const std::vector<std::string> elective_workload_keys = {
         "infile_dataset",
 };
 std::map<std::shared_ptr<wrench::StorageService>, LRU_FileList> SimpleSimulator::global_file_map;
-std::mt19937 SimpleSimulator::gen(42);                           // random number generator
+std::mt19937 SimpleSimulator::gen(42);                        // random number generator
 std::ofstream filedump;                                          // output file stream to write monitoring dump to
 bool SimpleSimulator::infile_caching_on = true;                  // flag to turn off/on the caching of job input-files
 bool SimpleSimulator::prefetching_on = true;                     // flag to enable prefetching during streaming
 bool SimpleSimulator::shuffle_jobs = false;                      // flag to enable job shuffling during submission
-double SimpleSimulator::xrd_block_size = 1. * 1000 * 1000 * 1000;// maximum size of the streamed file blocks in bytes for the XRootD-ish streaming
-double SimpleSimulator::xrd_add_flops_per_time = 20000000000;// flops overhead introduced by XRootD streaming per second
+sg_size_t SimpleSimulator::xrd_block_size = 1000 * 1000 * 1000;  // maximum size of the streamed file blocks in bytes for the XRootD-ish streaming
+double SimpleSimulator::xrd_add_flops_per_time = 20000000000;    // flops overhead introduced by XRootD streaming per second
 // TODO: The initialized below is likely bogus (at compile time?)
 std::set<std::string> SimpleSimulator::cache_hosts;
 std::set<std::string> SimpleSimulator::storage_hosts;
@@ -226,15 +226,16 @@ po::variables_map process_program_options(int argc, char **argv) {
     // default values
     double hitrate = 0.0;
 
-    double average_flops = 2164.428 * 1000 * 1000 * 1000;
-    double sigma_flops = 0.1 * average_flops;
-    double average_memory = 2. * 1000 * 1000 * 1000;
-    double sigma_memory = 0.1 * average_memory;
-    size_t infiles_per_job = 10;
-    double average_infile_size = 3600000000.;
-    double sigma_infile_size = 0.1 * average_infile_size;
-    double average_outfile_size = 0.5 * infiles_per_job * average_infile_size;
-    double sigma_outfile_size = 0.1 * average_outfile_size;
+    // HENRI: Commented the 9 lines below as they were not used (and include data-type weirdness)
+    // double average_flops = 2164.428 * 1000 * 1000 * 1000;
+    // double sigma_flops = 0.1 * average_flops;
+    // double average_memory = 2. * 1000 * 1000 * 1000;
+    // double sigma_memory = 0.1 * average_memory;
+    // size_t infiles_per_job = 10;
+    // double average_infile_size = 3600000000.;
+    // double sigma_infile_size = 0.1 * average_infile_size;
+    // double average_outfile_size = 0.5 * infiles_per_job * average_infile_size;
+    // double sigma_outfile_size = 0.1 * average_outfile_size;
 
 
     size_t duplications = 1;
@@ -243,7 +244,7 @@ po::variables_map process_program_options(int argc, char **argv) {
     bool prefetch_off = false;
     bool shuffle_jobs = false;
 
-    double xrd_block_size = 1000. * 1000 * 1000;
+    sg_size_t xrd_block_size = 1000 * 1000 * 1000;
     double xrd_add_flops_per_time = 20000000000;
     std::string storage_service_buffer_size = "1048576";// 1MiB
 
@@ -257,7 +258,7 @@ po::variables_map process_program_options(int argc, char **argv) {
     op("duplications,d", po::value<size_t>()->default_value(duplications), "number of duplications of the workload to feed into the simulation");
     op("no-caching", po::bool_switch()->default_value(no_caching), "switch to turn on/off the caching of jobs' input-files")("prefetch-off", po::bool_switch()->default_value(prefetch_off), "switch to turn on/off prefetching for streaming of input-files")("shuffle-jobs", po::bool_switch()->default_value(shuffle_jobs), "switch to turn on/off shuffling jobs during submission");
     op("output-file,o", po::value<std::string>()->value_name("<out file>")->required(), "path for the CSV file containing output information about the jobs in the simulation");
-    op("xrd-blocksize,x", po::value<double>()->default_value(xrd_block_size), "size of the blocks XRootD uses for data streaming")("storage-buffer-size,b", po::value<StorageServiceBufferValue>()->default_value(StorageServiceBufferValue(storage_service_buffer_size)), "buffer size used by the storage services when communicating data");
+    op("xrd-blocksize,x", po::value<sg_size_t>()->default_value(xrd_block_size), "size of the blocks XRootD uses for data streaming")("storage-buffer-size,b", po::value<StorageServiceBufferValue>()->default_value(StorageServiceBufferValue(storage_service_buffer_size)), "buffer size used by the storage services when communicating data");
     op("xrd-flops-per-time", po::value<double>()->default_value(xrd_add_flops_per_time), "flops overhead introduced by XRootD data streaming per second");
     op("cache-scope", po::value<cacheScope>()->default_value(cacheScope("local")), "Set the network scope in which caches can be found:\n local: only caches on same machine\n network: caches in same network zone\n siblingnetwork: also include caches in sibling networks");
     op("seed,s", po::value<unsigned int>()->default_value(seed), "Set the seed for the random generator");
@@ -452,7 +453,7 @@ int main(int argc, char **argv) {
     SimpleSimulator::shuffle_jobs = vm["shuffle-jobs"].as<bool>();
 
     // Set XRootD block size
-    SimpleSimulator::xrd_block_size = vm["xrd-blocksize"].as<double>();
+    SimpleSimulator::xrd_block_size = vm["xrd-blocksize"].as<sg_size_t>();
     SimpleSimulator::xrd_add_flops_per_time = vm["xrd-flops-per-time"].as<double>();
 
     // Set StorageService buffer size/type
@@ -480,7 +481,7 @@ int main(int argc, char **argv) {
 
     std::vector<Dataset> dataset_specs = {};
 
-    if (dataset_configurations.size() == 0) {
+    if (dataset_configurations.empty()) {
         //Default dataset config
     } else {
         for (auto &ds_confpath: dataset_configurations) {
@@ -740,8 +741,8 @@ int main(int argc, char **argv) {
         }
         for (auto const &wms: workload_execution_controllers) {
             for (auto &job_spec: wms->get_workload_spec()) {
-                double incr_infile_size = 0.;
-                double cached_files_size = 0.;
+                sg_size_t incr_infile_size = 0.;
+                sg_size_t cached_files_size = 0.;
                 for (auto const &f: job_spec.second.infiles) {
                     incr_infile_size += f->getSize();
                 }
@@ -750,7 +751,7 @@ int main(int argc, char **argv) {
 
                     // Distribute the files on all caches until desired hitrate is reached
                     // TODO: Rework the initialization of input files on caches
-                    if (cached_files_size < hitrate * incr_infile_size) {
+                    if (cached_files_size < static_cast<sg_size_t>(hitrate * static_cast<double>(incr_infile_size))) {
                         for (const auto &cache: cache_storage_services) {
                             // simulation->stageFile(f, cache);
                             wrench::StorageService::createFileAtLocation(wrench::FileLocation::LOCATION(cache, f));
@@ -759,7 +760,7 @@ int main(int argc, char **argv) {
                         cached_files_size += f->getSize();
                     }
                 }
-                if (cached_files_size / incr_infile_size < hitrate) {
+                if (static_cast<double>(cached_files_size) / static_cast<double>(incr_infile_size) < hitrate) {
                     throw std::runtime_error("Desired hitrate was not reached!");
                 }
             }

--- a/src/SimpleSimulator.h
+++ b/src/SimpleSimulator.h
@@ -32,7 +32,7 @@ public:
 
     static bool shuffle_jobs;
 
-    static double xrd_block_size;
+    static sg_size_t xrd_block_size;
     static double xrd_add_flops_per_time;
     static std::mt19937 gen;
 

--- a/src/SimpleSimulator.h
+++ b/src/SimpleSimulator.h
@@ -10,7 +10,7 @@
 class SimpleSimulator {
 
 public:
-    static void identifyHostTypes(std::shared_ptr<wrench::Simulation> simulation);
+    static void identifyHostTypes(const std::shared_ptr<wrench::Simulation> &simulation);
 
     static std::set<std::string> cache_hosts;     // hosts configured to provide a cache
     static std::set<std::string> storage_hosts;   // hosts configured to provide GRID storage

--- a/src/Workload.cpp
+++ b/src/Workload.cpp
@@ -23,20 +23,19 @@ std::string workload_type_to_string(WorkloadType workload) {
 
 /**
  * @brief Fill a Workload consisting of jobs with job specifications, 
- * which include the inputfile and outputfile dependencies.
- * It can be chosen between jobs streaming input data and perform computations simultaneously 
- * or jobs copying the full input-data and compute afterwards.
+ * which include the input file and outputfile dependencies.
+ * One can chose between jobs streaming input data and perform computations simultaneously
+ * or jobs copying the full input-data and performing the computation afterward.
  *    
  * @param num_jobs: number of tasks
- * @param infiles_per_task: number of input-files each job processes
+ * @param cores: json object containing type and parameters for the cores distribution
  * @param flops: json object containing type and parameters for the flops distribution
  * @param memory: json object containing type and parameters for the memory distribution
- * @param infile_size: json object containing type and parameters for the input-file size distribution
  * @param outfile_size: json object containing type and parameters for the output-file size distribution
- * @param workload_type: flag to specifiy, whether the job should run with streaming or not
  * @param name_suffix: part of job name to distinguish between different workloads
  * @param arrival_time: submission time offset relative to simulation start
  * @param generator: random number generator objects to draw from
+ * @param infile_datasets the input file dataset
  * 
  * @throw std::runtime_error
  */
@@ -46,23 +45,21 @@ Workload::Workload(
         nlohmann::json flops,
         nlohmann::json memory,
         nlohmann::json outfile_size,
-        const enum WorkloadType workload_type, const std::string name_suffix,
+        const enum WorkloadType workload_type,
+        const std::string &name_suffix,
         const double arrival_time,
         const std::mt19937 &generator,
-        const std::vector<std::string> infile_datasets) {
+        const std::vector<std::string> &infile_datasets) {
     this->generator = generator;
     // Map to store the workload specification
     std::vector<JobSpecification> batch;
-    std::string potential_separator = "_";
-    if (name_suffix == "") {
-        potential_separator = "";
-    }
+    std::string potential_separator = (name_suffix.empty() ? "" : "_");
 
     // Initialize random number generators
-    this->core_dist = Workload::initializeIntRNG(cores);
-    this->flops_dist = Workload::initializeDoubleRNG(flops);
-    this->mem_dist = Workload::initializeDoubleRNG(memory);
-    this->outsize_dist = Workload::initializeDoubleRNG(outfile_size);
+    this->core_dist = Workload::createIntRNG(cores);
+    this->flops_dist = Workload::createDoubleRNG(flops);
+    this->mem_dist = Workload::createDoubleRNG(memory);
+    this->outsize_dist = Workload::createDoubleRNG(outfile_size);
     for (size_t j = 0; j < num_jobs; j++) {
         batch.push_back(sampleJob(j, name_suffix, potential_separator));
     }
@@ -74,7 +71,7 @@ Workload::Workload(
         this->infile_datasets = infile_datasets;
 }
 
-std::function<double(std::mt19937 &)> Workload::initializeDoubleRNG(nlohmann::json json) {
+std::function<double(std::mt19937 &)> Workload::createDoubleRNG(nlohmann::json json) {
     // std::cerr << json["type"] << ": ";
     std::function<double(std::mt19937 &)> dist;
     if (json["type"].get<std::string>() == "gaussian") {
@@ -97,7 +94,7 @@ std::function<double(std::mt19937 &)> Workload::initializeDoubleRNG(nlohmann::js
     return dist;
 }
 
-std::function<int(std::mt19937 &)> Workload::initializeIntRNG(nlohmann::json json) {
+std::function<int(std::mt19937 &)> Workload::createIntRNG(nlohmann::json json) {
     // std::cerr << json["type"] << ": ";
     std::function<int(std::mt19937 &)> dist;
     if (json["type"].get<std::string>() == "poisson") {
@@ -123,7 +120,7 @@ std::function<int(std::mt19937 &)> Workload::initializeIntRNG(nlohmann::json jso
 }
 
 
-JobSpecification Workload::sampleJob(size_t job_id, std::string name_suffix, std::string potential_separator) {
+JobSpecification Workload::sampleJob(size_t job_id, const std::string &name_suffix, const std::string &potential_separator) {
     // Create a job specification
     JobSpecification job_specification;
 
@@ -142,12 +139,14 @@ JobSpecification Workload::sampleJob(size_t job_id, std::string name_suffix, std
     // Sample strictly positive task memory requirements
     double dmem = this->mem_dist(this->generator);
     while (dmem < 0.) dmem = this->mem_dist(this->generator);
-    job_specification.total_mem = dmem;
+    auto dmem_in_bytes = static_cast<sg_size_t>(dmem);
+    job_specification.total_mem = dmem_in_bytes;
 
     // Sample outfile sizes
     double doutsize = this->outsize_dist(this->generator);
     while (doutsize < 0.) doutsize = this->outsize_dist(this->generator);
-    job_specification.outfile = wrench::Simulation::addFile("outfile_" + name_suffix + potential_separator + std::to_string(j), doutsize);
+    auto doutsize_in_bytes = static_cast<sg_size_t>(doutsize);
+    job_specification.outfile = wrench::Simulation::addFile("outfile_" + name_suffix + potential_separator + std::to_string(j), doutsize_in_bytes);
 
     job_specification.jobid = "job_" + name_suffix + potential_separator + std::to_string(j);
 
@@ -159,7 +158,6 @@ void transform_if(InputIt first, InputIt last, OutputIt dest, Pred pred, Fct tra
     while (first != last) {
         if (pred(*first))
             *dest++ = transform(*first);
-
         ++first;
     }
 }
@@ -171,17 +169,17 @@ void Workload::assignFiles(std::vector<Dataset> const &dataset_specs) {
             [&](Dataset const &ds) { return &ds; });
     if (matching_ds.empty())
         throw std::runtime_error("ERROR: no valid infile dataset name in workload configuration.");
-    int num_files = std::accumulate(matching_ds.begin(), matching_ds.end(), 0, [](int sum, Dataset const *ds) { return sum + ds->files.size(); });
+    size_t num_files = std::accumulate(matching_ds.begin(), matching_ds.end(), 0, [](int sum, Dataset const *ds) { return sum + ds->files.size(); });
     std::vector<std::shared_ptr<wrench::DataFile>> all_files{};
     all_files.reserve(num_files);
     for (auto const &ds: matching_ds) {
         std::copy(ds->files.begin(), ds->files.end(), std::back_inserter(all_files));
     }
-    int num_jobs = job_batch.size();
+    size_t num_jobs = job_batch.size();
     if (num_jobs == 0)
         return;
     // int num_files = all_files.size();
-    int k = num_files / num_jobs;
+    size_t k = num_files / num_jobs;
     std::cerr << "Assigning " << num_files << " files to " << num_jobs << " jobs\n";
     for (auto j = 0; j < num_jobs; ++j) {
         auto beg_it = all_files.begin() + j * k;

--- a/src/Workload.h
+++ b/src/Workload.h
@@ -57,9 +57,9 @@ public:
             nlohmann::json flops,
             nlohmann::json memory,
             nlohmann::json outfile_size,
-            const WorkloadType workload_type, const std::string name_suffix,
+            const WorkloadType workload_type, const std::string &name_suffix,
             const double arrival_time, const std::mt19937 &generator,
-            const std::vector<std::string> infile_datasets = {});
+            const std::vector<std::string> &infile_datasets = {});
 
     // job list with specifications
     std::vector<JobSpecification> job_batch;
@@ -79,10 +79,10 @@ private:
     std::function<double(std::mt19937 &)> mem_dist;
     std::function<double(std::mt19937 &)> outsize_dist;
 
-    std::function<int(std::mt19937 &)> initializeIntRNG(nlohmann::json json);
-    std::function<double(std::mt19937 &)> initializeDoubleRNG(nlohmann::json json);
+    static std::function<int(std::mt19937 &)> createIntRNG(nlohmann::json json);
+    static std::function<double(std::mt19937 &)> createDoubleRNG(nlohmann::json json);
 
-    JobSpecification sampleJob(const size_t job_id, std::string name_suffix, std::string potential_separator);
+    JobSpecification sampleJob(const size_t job_id, const std::string &name_suffix, const std::string &potential_separator);
 };
 
 

--- a/src/Workload.h
+++ b/src/Workload.h
@@ -28,7 +28,7 @@ std::string workload_type_to_string(WorkloadType);
 
 // enum class WorkloadType {Calculation, Streaming, Copy};
 
-inline WorkloadType get_workload_type(std::string wfname) {
+inline WorkloadType get_workload_type(const std::string &wfname) {
     if (wfname == "calculation") {
         return WorkloadType::Calculation;
     } else if (wfname == "streaming") {
@@ -52,13 +52,13 @@ class Workload {
 public:
     // Constructor
     Workload(
-            const size_t num_jobs,
+            size_t num_jobs,
             nlohmann::json cores,
             nlohmann::json flops,
             nlohmann::json memory,
             nlohmann::json outfile_size,
-            const WorkloadType workload_type, const std::string &name_suffix,
-            const double arrival_time, const std::mt19937 &generator,
+            WorkloadType workload_type, const std::string &name_suffix,
+            double arrival_time, const std::mt19937 &generator,
             const std::vector<std::string> &infile_datasets = {});
 
     // job list with specifications
@@ -82,7 +82,7 @@ private:
     static std::function<int(std::mt19937 &)> createIntRNG(nlohmann::json json);
     static std::function<double(std::mt19937 &)> createDoubleRNG(nlohmann::json json);
 
-    JobSpecification sampleJob(const size_t job_id, const std::string &name_suffix, const std::string &potential_separator);
+    JobSpecification sampleJob(size_t job_id, const std::string &name_suffix, const std::string &potential_separator);
 };
 
 

--- a/src/WorkloadExecutionController.cpp
+++ b/src/WorkloadExecutionController.cpp
@@ -160,7 +160,7 @@ void WorkloadExecutionController::setJobSubmitted(const std::string &job_name) {
  * @brief Method to determine whether all jobs have been submitted
  * @return True is all jobs have been submitted, false otherwise
  */
-bool WorkloadExecutionController::isWorkloadEmpty() {
+bool WorkloadExecutionController::isWorkloadEmpty() const {
     return this->workload_spec.empty();
 }
 

--- a/src/WorkloadExecutionController.cpp
+++ b/src/WorkloadExecutionController.cpp
@@ -283,9 +283,9 @@ void WorkloadExecutionController::processEventCompoundJobCompletion(
     /* Remove all actions from memory and compute incremental output values in one loop */
     double incr_compute_time = DefaultValues::UndefinedDouble;
     double incr_infile_transfertime = 0.;
-    double incr_infile_size = 0.;
+    sg_size_t incr_infile_size = 0.;
     double incr_outfile_transfertime = 0.;
-    double incr_outfile_size = 0.;
+    sg_size_t incr_outfile_size = 0.;
     double global_start_date = DBL_MAX;
     double global_end_date = DBL_MIN;
     double hitrate = DefaultValues::UndefinedDouble;

--- a/src/WorkloadExecutionController.h
+++ b/src/WorkloadExecutionController.h
@@ -48,7 +48,7 @@ public:
                                                             const std::shared_ptr<wrench::ComputeService> &cs);
     void setJobSubmitted(const std::string &job_name);
 
-    bool isWorkloadEmpty();
+    bool isWorkloadEmpty() const;
 
 protected:
     void processEventCompoundJobFailure(const std::shared_ptr<wrench::CompoundJobFailedEvent>& event) override;

--- a/src/computation/CacheComputation.cpp
+++ b/src/computation/CacheComputation.cpp
@@ -17,10 +17,10 @@ XBT_LOG_NEW_DEFAULT_CATEGORY(cache_computation, "Log category for CacheComputati
  * @param files Input files of the job to process
  * @param total_flops Total #FLOPS of the whole compute action of the job
  */
-CacheComputation::CacheComputation(std::set<std::shared_ptr<wrench::StorageService>> &cache_storage_services,
-                                   std::set<std::shared_ptr<wrench::StorageService>> &grid_storage_services,
-                                   std::vector<std::shared_ptr<wrench::DataFile>> &files,
-                                   double total_flops) {
+CacheComputation::CacheComputation(const std::set<std::shared_ptr<wrench::StorageService>> &cache_storage_services,
+                                   const std::set<std::shared_ptr<wrench::StorageService>> &grid_storage_services,
+                                   const std::vector<std::shared_ptr<wrench::DataFile>> &files,
+                                   const double total_flops) : total_flops_(total_flops) {
     this->cache_storage_services = cache_storage_services;
     this->grid_storage_services = grid_storage_services;
     this->files = files;
@@ -36,9 +36,10 @@ CacheComputation::CacheComputation(std::set<std::shared_ptr<wrench::StorageServi
  * TODO: Find some optimal sources serving and destinations providing files to jobs.
  * TODO: Find solutions for possible race conditions, when several jobs require same files.
  * 
- * @param hostname Name of the host, where the job runs
+ * @param action_executor: action executor used for this computation
+ * @param cache_files: whether to cache files locally or not
  */
-void CacheComputation::determineFileSourcesAndCache(std::shared_ptr<wrench::ActionExecutor> action_executor, bool cache_files = true) {
+void CacheComputation::determineFileSourcesAndCache(const std::shared_ptr<wrench::ActionExecutor>& action_executor, bool cache_files = true) {
 
     std::string hostname = action_executor->getHostname();// host where action is executed
     auto host = simgrid::s4u::Host::by_name(hostname);
@@ -91,7 +92,7 @@ void CacheComputation::determineFileSourcesAndCache(std::shared_ptr<wrench::Acti
         if (source_ss) {
             SimpleSimulator::global_file_map[source_ss].touchFile(f.get());
             // this->file_sources[f] = wrench::FileLocation::LOCATION(source_ss, f);
-            file_sources.emplace_back(std::make_pair(f, wrench::FileLocation::LOCATION(source_ss, f)));
+            file_sources.emplace_back(f, wrench::FileLocation::LOCATION(source_ss, f));
             continue;
         }
         // If not, then we have to copy the file from some GRID source to some reachable cache storage service
@@ -149,7 +150,7 @@ void CacheComputation::determineFileSourcesAndCache(std::shared_ptr<wrench::Acti
         }
 
         // this->file_sources[f] = wrench::FileLocation::LOCATION(source_ss, f);
-        file_sources.emplace_back(std::make_pair(f, wrench::FileLocation::LOCATION(source_ss, f)));
+        file_sources.emplace_back(f, wrench::FileLocation::LOCATION(source_ss, f));
     }
 
     // Fill monitoring information
@@ -167,9 +168,9 @@ void CacheComputation::determineFileSourcesAndCache(std::shared_ptr<wrench::Acti
  * @brief Determine the incremental size of all input-files of a job
  * 
  * @param files Input files of the job to consider
- * @return double
+ * @return a data size
  */
-sg_size_t CacheComputation::determineTotalDataSize(const std::vector<std::shared_ptr<wrench::DataFile>> &files) {
+sg_size_t CacheComputation::determineTotalDataSize(const std::vector<std::shared_ptr<wrench::DataFile>> &files) const {
     sg_size_t incr_file_size = 0;
     for (auto const &f: this->files) {
         incr_file_size += f->getSize();
@@ -182,7 +183,7 @@ sg_size_t CacheComputation::determineTotalDataSize(const std::vector<std::shared
  * 
  * @param action_executor 
  */
-void CacheComputation::operator()(std::shared_ptr<wrench::ActionExecutor> action_executor) {
+void CacheComputation::operator()(const std::shared_ptr<wrench::ActionExecutor> &action_executor) {
     std::string hostname = action_executor->getHostname();
 
     // Identify all file sources (and deal with caching, evictions, etc.
@@ -199,9 +200,9 @@ void CacheComputation::operator()(std::shared_ptr<wrench::ActionExecutor> action
  * 
  * @param data_size Size of the input-data block considered
  * @param total_data_size Total incremental size of all input-files
- * @return double 
+ * @return a number of flops
  */
-double CacheComputation::determineFlops(sg_size_t data_size, sg_size_t total_data_size) const {
+double CacheComputation::determineFlops(const sg_size_t data_size, const sg_size_t total_data_size) const {
     double flops = this->total_flops * static_cast<double>(data_size) / static_cast<double>(total_data_size);
     return flops;
 }
@@ -211,7 +212,7 @@ double CacheComputation::determineFlops(sg_size_t data_size, sg_size_t total_dat
  * 
  * @param action_executor Handle to access the action this computation belongs to
  */
-void CacheComputation::performComputation(std::shared_ptr<wrench::ActionExecutor> action_executor) {
+void CacheComputation::performComputation(const std::shared_ptr<wrench::ActionExecutor> &action_executor) {
     throw std::runtime_error(
             "Base class CacheComputation has no performComputation implemented! \
         It is meant only as a purely virtual placeholder. \

--- a/src/computation/CacheComputation.h
+++ b/src/computation/CacheComputation.h
@@ -22,7 +22,7 @@ public:
 
     void operator()(std::shared_ptr<wrench::ActionExecutor> action_executor);
 
-    double determineFlops(double data_size, double total_data_size);
+    double determineFlops(sg_size_t data_size, sg_size_t total_data_size) const;
 
     virtual void performComputation(std::shared_ptr<wrench::ActionExecutor> action_executor) = 0;
 
@@ -34,8 +34,8 @@ protected:
 
     std::vector<std::pair<std::shared_ptr<wrench::DataFile>, std::shared_ptr<wrench::FileLocation>>> file_sources;
 
-    double determineTotalDataSize(const std::vector<std::shared_ptr<wrench::DataFile>> &files);
-    double total_data_size;
+    sg_size_t determineTotalDataSize(const std::vector<std::shared_ptr<wrench::DataFile>> &files);
+    sg_size_t total_data_size;
 };
 
 #endif//S_CACHECOMPUTATION_H

--- a/src/computation/CacheComputation.h
+++ b/src/computation/CacheComputation.h
@@ -11,20 +11,20 @@ class CacheComputation {
 
 public:
     CacheComputation(
-            std::set<std::shared_ptr<wrench::StorageService>> &cache_storage_services,
-            std::set<std::shared_ptr<wrench::StorageService>> &grid_storage_services,
-            std::vector<std::shared_ptr<wrench::DataFile>> &files,
+            const std::set<std::shared_ptr<wrench::StorageService>> &cache_storage_services,
+            const std::set<std::shared_ptr<wrench::StorageService>> &grid_storage_services,
+            const std::vector<std::shared_ptr<wrench::DataFile>> &files,
             double total_flops);
 
     virtual ~CacheComputation() = default;
 
-    void determineFileSourcesAndCache(std::shared_ptr<wrench::ActionExecutor> action_executor, bool cache_files);
+    void determineFileSourcesAndCache(const std::shared_ptr<wrench::ActionExecutor>& action_executor, bool cache_files);
 
-    void operator()(std::shared_ptr<wrench::ActionExecutor> action_executor);
+    void operator()(const std::shared_ptr<wrench::ActionExecutor> &action_executor);
 
-    double determineFlops(sg_size_t data_size, sg_size_t total_data_size) const;
+    [[nodiscard]] double determineFlops(sg_size_t data_size, sg_size_t total_data_size) const;
 
-    virtual void performComputation(std::shared_ptr<wrench::ActionExecutor> action_executor) = 0;
+    virtual void performComputation(const std::shared_ptr<wrench::ActionExecutor> &action_executor);
 
 protected:
     std::set<std::shared_ptr<wrench::StorageService>> cache_storage_services;
@@ -33,8 +33,9 @@ protected:
     double total_flops;
 
     std::vector<std::pair<std::shared_ptr<wrench::DataFile>, std::shared_ptr<wrench::FileLocation>>> file_sources;
+    double total_flops_;
 
-    sg_size_t determineTotalDataSize(const std::vector<std::shared_ptr<wrench::DataFile>> &files);
+    sg_size_t determineTotalDataSize(const std::vector<std::shared_ptr<wrench::DataFile>> &files) const;
     sg_size_t total_data_size;
 };
 

--- a/src/computation/CopyComputation.cpp
+++ b/src/computation/CopyComputation.cpp
@@ -10,15 +10,16 @@ XBT_LOG_NEW_DEFAULT_CATEGORY(copy_computation, "Log category for CopyComputation
  * to be used as a lambda within a compute action, which shall take caching of input-files into account.
  * File read of all input-files and compute steps are performed sequentially.
  * 
- * @param storage_services Storage services reachable to retrieve input files (caches plus remote)
+ * @param cache_storage_services Storage services reachable to retrieve input files (caches)
+ * @param grid_storage_services Storage services reachable to retrieve input files (remote)
  * @param files Input files of the job to process
  * @param total_flops Total #FLOPS of the whole compute action of the job
  */
 CopyComputation::CopyComputation(
-        std::set<std::shared_ptr<wrench::StorageService>> &cache_storage_services,
-        std::set<std::shared_ptr<wrench::StorageService>> &grid_storage_services,
-        std::vector<std::shared_ptr<wrench::DataFile>> &files,
-        double total_flops) : CacheComputation::CacheComputation(cache_storage_services,
+        const std::set<std::shared_ptr<wrench::StorageService>> &cache_storage_services,
+        const std::set<std::shared_ptr<wrench::StorageService>> &grid_storage_services,
+        const std::vector<std::shared_ptr<wrench::DataFile>> &files,
+        const double total_flops) : CacheComputation::CacheComputation(cache_storage_services,
                                                                  grid_storage_services,
                                                                  files,
                                                                  total_flops) {}
@@ -29,7 +30,7 @@ CopyComputation::CopyComputation(
  * 
  * @param action_executor Handle to access the action this computation belongs to
  */
-void CopyComputation::performComputation(std::shared_ptr<wrench::ActionExecutor> action_executor) {
+void CopyComputation::performComputation(const std::shared_ptr<wrench::ActionExecutor> &action_executor) {
 
     auto the_action = std::dynamic_pointer_cast<MonitorAction>(action_executor->getAction());// executed action
 
@@ -38,9 +39,9 @@ void CopyComputation::performComputation(std::shared_ptr<wrench::ActionExecutor>
 
     WRENCH_INFO("Performing copy computation!");
     // Incremental size of all input files to process
-    double total_data_size = this->total_data_size;
+    sg_size_t total_data_size = this->total_data_size;
     // Read all input files before computation
-    double data_size = 0;
+    sg_size_t data_size = 0;
     for (auto const &fs: this->file_sources) {
         WRENCH_INFO("Reading file %s from storage service on host %s",
                     fs.first->getID().c_str(), fs.second->getStorageService()->getHostname().c_str());
@@ -57,7 +58,7 @@ void CopyComputation::performComputation(std::shared_ptr<wrench::ActionExecutor>
                     "Reading file " + fs.first->getID() + " finished before it started!");
         }
     }
-    if (!(std::abs(data_size - total_data_size) < 1.)) {
+    if (data_size > total_data_size) {
         throw std::runtime_error("Something went wrong in the data size computation!");
     }
 

--- a/src/computation/CopyComputation.cpp
+++ b/src/computation/CopyComputation.cpp
@@ -58,7 +58,7 @@ void CopyComputation::performComputation(const std::shared_ptr<wrench::ActionExe
                     "Reading file " + fs.first->getID() + " finished before it started!");
         }
     }
-    if (data_size > total_data_size) {
+    if (data_size != total_data_size) {
         throw std::runtime_error("Something went wrong in the data size computation!");
     }
 

--- a/src/computation/CopyComputation.h
+++ b/src/computation/CopyComputation.h
@@ -11,12 +11,12 @@ class CopyComputation : public CacheComputation {
 
 public:
     CopyComputation(
-            std::set<std::shared_ptr<wrench::StorageService>> &cache_storage_services,
-            std::set<std::shared_ptr<wrench::StorageService>> &grid_storage_services,
-            std::vector<std::shared_ptr<wrench::DataFile>> &files,
+            const std::set<std::shared_ptr<wrench::StorageService>> &cache_storage_services,
+            const std::set<std::shared_ptr<wrench::StorageService>> &grid_storage_services,
+            const std::vector<std::shared_ptr<wrench::DataFile>> &files,
             double total_flops);
 
-    void performComputation(std::shared_ptr<wrench::ActionExecutor> action_executor) override;
+    void performComputation(const std::shared_ptr<wrench::ActionExecutor> &action_executor) override;
 
 private:
 };

--- a/src/computation/StreamedComputation.cpp
+++ b/src/computation/StreamedComputation.cpp
@@ -46,14 +46,14 @@ void StreamedComputation::performComputation(std::shared_ptr<wrench::ActionExecu
     auto total_data_size = this->total_data_size;
     for (auto const &fs: this->file_sources) {
         WRENCH_INFO("Streaming computation for input file %s in location %s", fs.first->getID().c_str(), fs.second->getStorageService()->getHostname().c_str());
-        double data_to_process = fs.first->getSize();
+        sg_size_t data_to_process = fs.first->getSize();
 
         // Compute the number of blocks
-        int num_blocks = int(std::ceil(data_to_process / (double) SimpleSimulator::xrd_block_size));
+        auto num_blocks = static_cast<int>(std::ceil(data_to_process / static_cast<double>(SimpleSimulator::xrd_block_size)));
 
         // Read the first block
         double read_start_time = wrench::Simulation::getCurrentSimulatedDate();
-        fs.second->getStorageService()->readFile(fs.second, std::min<double>(SimpleSimulator::xrd_block_size, data_to_process));
+        fs.second->getStorageService()->readFile(fs.second, std::min<sg_size_t>(SimpleSimulator::xrd_block_size, data_to_process));
         double read_end_time = wrench::Simulation::getCurrentSimulatedDate();
         if (read_end_time > read_start_time) {
             infile_transfer_time += read_end_time - read_start_time;
@@ -66,7 +66,7 @@ void StreamedComputation::performComputation(std::shared_ptr<wrench::ActionExecu
 
         // Process next blocks: compute block i while reading block i+i
         for (int i = 0; i < num_blocks - 1; i++) {
-            double num_bytes = std::min<double>(SimpleSimulator::xrd_block_size, data_to_process);
+            auto num_bytes = std::min<sg_size_t>(SimpleSimulator::xrd_block_size, data_to_process);
             double num_flops = determineFlops(num_bytes, total_data_size);
             WRENCH_INFO("Chunk: %.2lf bytes / %.2lf flops", num_bytes, num_flops);
             // Add XRootD FLOPs overhead that increments with execution time

--- a/src/computation/StreamedComputation.cpp
+++ b/src/computation/StreamedComputation.cpp
@@ -68,7 +68,7 @@ void StreamedComputation::performComputation(std::shared_ptr<wrench::ActionExecu
         for (int i = 0; i < num_blocks - 1; i++) {
             auto num_bytes = std::min<sg_size_t>(SimpleSimulator::xrd_block_size, data_to_process);
             double num_flops = determineFlops(num_bytes, total_data_size);
-            WRENCH_INFO("Chunk: %.2lf bytes / %.2lf flops", num_bytes, num_flops);
+            WRENCH_INFO("Chunk: %llu bytes / %.2lf flops", num_bytes, num_flops);
             // Add XRootD FLOPs overhead that increments with execution time
             double xrd_overhead_flops = SimpleSimulator::xrd_add_flops_per_time * (wrench::Simulation::getCurrentSimulatedDate() - job_start_time);
             num_flops += xrd_overhead_flops;

--- a/src/computation/StreamedComputation.h
+++ b/src/computation/StreamedComputation.h
@@ -13,12 +13,12 @@ public:
     // TODO: REMOVE MOST THINGS IN HERE AND RELY ON THE GLOBALS IN SimpleSimulation::...
     StreamedComputation(
             std::set<std::shared_ptr<wrench::StorageService>> &cache_storage_services,
-            std::set<std::shared_ptr<wrench::StorageService>> &grid_storage_services,
-            std::vector<std::shared_ptr<wrench::DataFile>> &files,
+            const std::set<std::shared_ptr<wrench::StorageService>> &grid_storage_services,
+            const std::vector<std::shared_ptr<wrench::DataFile>> &files,
             double total_flops,
             bool prefetch_on);
 
-    void performComputation(std::shared_ptr<wrench::ActionExecutor> action_executor) override;
+    void performComputation(const std::shared_ptr<wrench::ActionExecutor> &action_executor) override;
 
 private:
     bool prefetching_on;

--- a/src/util/Utils.h
+++ b/src/util/Utils.h
@@ -23,7 +23,7 @@ enum StorageServiceBufferType {
  * @param ssprop 
  * @return StorageServiceBufferType 
  */
-inline StorageServiceBufferType get_ssbuffer_type(std::string ssprop) {
+inline StorageServiceBufferType get_ssbuffer_type(const std::string &ssprop) {
     if ((ssprop == "infinity") or (ssprop == "inf")) {
         return StorageServiceBufferType::Infinity;
     } else if ((ssprop == "0") or (ssprop == "zero")) {


### PR DESCRIPTION
- Changed many double to sg_size_t (or added appropriate casts)
- In the process, did a round of minor fixes and code cleanups (as, mostly, suggested by the IDE)