### PR TITLE
Update versions for dependency packages to fix correct minimum cmake

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 		"dockerfile": "../Dockerfile",
 		"args": {
 			"IMAGE_REGISTRY": "mhorzela",
-			"IMAGE_TAG": "simcal-calibrator"
+			"IMAGE_TAG": "pr-78"
 		}
 	}
 

--- a/.github/workflows/github-docker.yaml
+++ b/.github/workflows/github-docker.yaml
@@ -17,17 +17,17 @@ jobs:
     steps:
       - 
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - 
         name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             mhorzela/dcsim
@@ -39,14 +39,14 @@ jobs:
             type=ref,event=pr
       -
         name: Login to Docker Hub
-        # if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.base

--- a/.github/workflows/github-docker.yaml
+++ b/.github/workflows/github-docker.yaml
@@ -51,6 +51,7 @@ jobs:
           context: .
           file: ./Dockerfile.base
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          # push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/github-docker.yaml
+++ b/.github/workflows/github-docker.yaml
@@ -39,7 +39,7 @@ jobs:
             type=ref,event=pr
       -
         name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,74 @@
 cmake_minimum_required(VERSION 3.12)
 message(STATUS "Cmake version ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}")
 
-project(DCSim)
+project(DCSim CXX)
 
 add_definitions("-Wall -Wno-unused-variable -Wno-unused-private-field")
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
-
-find_package(SimGrid REQUIRED)
-find_package(WRENCH REQUIRED)
-find_package(FSMod REQUIRED)
 
 # Find Boost
 if(POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
 endif()
 find_package(Boost COMPONENTS program_options regex REQUIRED)
+
+# Find SimGrid
+if (DEFINED SimGrid_PATH)
+    if (NOT EXISTS "${SimGrid_PATH}")
+        message(FATAL_ERROR "The specified SimGrid_PATH doesn't exit")
+    else()
+        file(GLOB LIBSIMGRID_FILES
+                "${SimGrid_PATH}/lib/libsimgrid.so"
+                "${SimGrid_PATH}/lib/libsimgrid.dylib"
+        )
+        if (NOT LIBSIMGRID_FILES)
+            message(FATAL_ERROR "The specified SimGrid_PATH doesn't seem to contain a valid SimGrid installation")
+        else()
+            set(CMAKE_PREFIX_PATH ${SimGrid_PATH} ${CMAKE_PREFIX_PATH})
+        endif()
+    endif()
+endif()
+find_package(SimGrid REQUIRED)
+
+# Find SimGrid's FS module
+if (DEFINED FSMOD_PATH)
+    if (NOT EXISTS "${FSMOD_PATH}")
+        message(FATAL_ERROR "The specified FSMOD_PATH doesn't exit")
+    else()
+        file(GLOB LIBFSMOD_FILES
+                "${FSMOD_PATH}/liblibfsmod.so"
+                "${FSMOD_PATH}/lib/libfsmod.dylib"
+        )
+        if (NOT LIBFSMOD_FILES)
+            message(FATAL_ERROR "The specified FSMOD_PATH doesn't seem to contain a valid FSMod installation")
+        else()
+            set(CMAKE_PREFIX_PATH ${FSMOD_PATH} ${CMAKE_PREFIX_PATH})
+        endif()
+    endif()
+endif()
+find_package(FSMod REQUIRED)
+
+# Find WRENCH
+if (DEFINED WRENCH_PATH)
+    if (NOT EXISTS "${WRENCH_PATH}")
+        message(FATAL_ERROR "The specified WRENCH_PATH doesn't exit")
+    else()
+        file(GLOB LIBWRENCH_FILES
+                "${WRENCH_PATH}/lib/libwrench.a"
+        )
+        if (NOT LIBWRENCH_FILES)
+            message(FATAL_ERROR "The specified WRENCH_PATH doesn't seem to contain a valid WRENCH installation")
+        else()
+            set(CMAKE_PREFIX_PATH ${WRENCH_PATH} ${CMAKE_PREFIX_PATH})
+        endif()
+    endif()
+endif()
+find_package(WRENCH REQUIRED)
 
 
 # include directories for dependencies and WRENCH libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ message(STATUS "Cmake version ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CM
 
 project(DCSim CXX)
 
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 add_definitions("-Wall -Wno-unused-variable -Wno-unused-private-field")
 
 set(CMAKE_CXX_STANDARD 23)

--- a/checkout_scripts/checkout_with_sudo.sh
+++ b/checkout_scripts/checkout_with_sudo.sh
@@ -33,12 +33,12 @@ WRENCH_tag="v2.5"
 #
 # 1) pugixml, docu: https://pugixml.org/docs/manual.html, git: https://github.com/zeux/pugixml
 echo "Installing C++ XML processing library pugixml..."
-if [ ! -d "$work_dir/pugixml-1.12.1" ]; then
-    wget http://github.com/zeux/pugixml/releases/download/v1.12.1/pugixml-1.12.1.tar.gz
-    tar -xf pugixml-1.12.1.tar.gz
-    rm pugixml-1.12.1.tar.gz
+if [ ! -d "$work_dir/pugixml-1.14" ]; then
+    wget http://github.com/zeux/pugixml/releases/download/v1.14/pugixml-1.14.tar.gz
+    tar -xf pugixml-1.14.tar.gz
+    rm pugixml-1.14.tar.gz
 fi
-pushd pugixml-1.12
+pushd pugixml-1.14
 mkdir -p build
 cd build
 cmake ..
@@ -48,12 +48,12 @@ popd
 
 # 2) nlohmann json, docu: https://json.nlohmann.me/, git: https://github.com/nlohmann/json
 echo "Installing C++ JSON library..."
-if [ ! -d "$work_dir/json-3.11.2" ]; then
-    wget https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.tar.gz
-    tar -xf v3.11.2.tar.gz
-    rm v3.11.2.tar.gz
+if [ ! -d "$work_dir/json-3.12.0" ]; then
+    wget https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.tar.gz
+    tar -xf v3.12.0.tar.gz
+    rm v3.12.0.tar.gz
 fi
-pushd json-3.11.2
+pushd json-3.12.0
 mkdir -p build
 cd build
 cmake ..

--- a/checkout_scripts/checkout_with_sudo.sh
+++ b/checkout_scripts/checkout_with_sudo.sh
@@ -26,7 +26,7 @@ fi
 
 # Release tag for SimGrid and WRENCH. If not specified will directly clone the repository
 SimGrid_tag="v3.36"
-SimGridFS_tag="v0.2"
+SimGridFS_tag="v0.3"
 WRENCH_tag="v2.5"
 
 # checking out packages from git as prerequisites for WRENCH:

--- a/checkout_scripts/checkout_with_sudo.sh
+++ b/checkout_scripts/checkout_with_sudo.sh
@@ -25,9 +25,9 @@ else
 fi
 
 # Release tag for SimGrid and WRENCH. If not specified will directly clone the repository
-SimGrid_tag="v3.36"
-SimGridFS_tag="v0.3"
-WRENCH_tag="v2.5"
+SimGrid_tag="v4.1"
+SimGridFS_tag="v0.4.1"
+WRENCH_tag="v2.8"
 
 # checking out packages from git as prerequisites for WRENCH:
 #
@@ -78,12 +78,6 @@ popd
 
 # 4) simgrid, docu: https://simgrid.org/doc/latest/, git: https://framagit.org/simgrid/simgrid
 echo "Installing SimGrid..."
-# if [ ! -d "$work_dir/simgrid-v3.32" ]; then
-#     wget https://framagit.org/simgrid/simgrid/-/archive/v3.32/simgrid-v3.32.tar.gz
-#     tar -xf simgrid-v3.32.tar.gz
-#     rm simgrid-v3.32.tar.gz
-# fi
-# pushd simgrid-v3.32
 if [ ! -d "$work_dir/simgrid" ]; then
     if [ -n "$SimGrid_tag" ]; then
         # If SimGrid_tag is specified, run the git clone command with the tag
@@ -96,7 +90,22 @@ fi
 pushd simgrid
 mkdir -p build
 cd build
-cmake ..
+# On macOS, help CMake find gfortran, help CMake find boost
+CMAKE_ARGS=""
+if [[ "$OSTYPE" == "darwin"* ]] && command -v gfortran &> /dev/null; then
+    echo "Setting LDFLAGS for gfortran on macOS..."
+    GFORTRAN_LIB=$(dirname $(find $(dirname $(gfortran -print-file-name=libgfortran.a)) -name "libgfortran*" 2>/dev/null | head -1))
+    if [ -n "$GFORTRAN_LIB" ]; then
+        export LDFLAGS="-L$GFORTRAN_LIB"
+    fi
+    if [ -d "/opt/homebrew/opt/boost" ]; then
+        CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/opt/homebrew/opt/boost"
+    elif [ -d "/usr/local/opt/boost" ]; then
+        CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/usr/local/opt/boost"
+    fi
+fi
+cmake $CMAKE_ARGS ..
+# cmake -Denable_fortran=OFF ..
 # cmake -DCMAKE_BUILD_TYPE=Debug ..
 make -j "$num_procs"; sudo make install
 popd

--- a/checkout_scripts/install_conda_environment.sh
+++ b/checkout_scripts/install_conda_environment.sh
@@ -48,7 +48,7 @@ mkdir -p DCSim; cd DCSim
 git clone https://github.com/zeux/pugixml.git
 mkdir -p pugixml/build
 pushd pugixml/build
-git checkout tags/v1.12.1
+git checkout tags/v1.14
 cmake -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ../
 make -j${NCORES}
 make install
@@ -58,7 +58,7 @@ popd
 git clone https://github.com/nlohmann/json.git
 mkdir -p json/build
 pushd json/build
-git checkout tags/v3.11.2
+git checkout tags/v3.12.0
 cmake -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ../
 make -j${NCORES}
 make install
@@ -78,7 +78,7 @@ popd
 git clone https://framagit.org/simgrid/simgrid.git
 mkdir -p simgrid/build
 pushd simgrid/build
-git checkout tags/v3.36
+git checkout tags/v4.1
 cmake -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ../
 make -j${NCORES}
 make install
@@ -88,7 +88,7 @@ popd
 git clone https://framagit.org/simgrid/file-system-module.git
 mkdir -p file-system-module/build
 pushd file-system-module/build
-git checkout tags/v0.2
+git checkout tags/v0.4.1
 cmake -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ../
 make -j${NCORES}
 make install
@@ -98,7 +98,7 @@ popd
 git clone https://github.com/wrench-project/wrench.git
 mkdir -p wrench/build
 pushd wrench/build
-git checkout tags/v2.5
+git checkout tags/v2.8
 cmake -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ../
 make -j${NCORES}
 make install

--- a/src/Workload.cpp
+++ b/src/Workload.cpp
@@ -185,9 +185,9 @@ void Workload::assignFiles(std::vector<Dataset> const &dataset_specs) {
     // int num_files = all_files.size();
     size_t k = num_files / num_jobs;
     std::cerr << "Assigning " << num_files << " files to " << num_jobs << " jobs\n";
-    for (auto j = 0; j < num_jobs; ++j) {
-        auto beg_it = all_files.begin() + j * k;
-        if (std::distance(beg_it, all_files.end()) < k) {
+    for (size_t j = 0; j < num_jobs; ++j) {
+        auto beg_it = all_files.begin() + static_cast<std::ptrdiff_t>(j * k);
+        if (std::distance(beg_it, all_files.end()) < static_cast<std::ptrdiff_t>(k)) {
             std::copy(beg_it, all_files.end(), std::back_inserter(job_batch[j].infiles));
             break;
         }


### PR DESCRIPTION
CMake has dropped support for versions smaller than 3.5. 
Since multiple dependencies were still requiring a minimum CMake smaller than version 3.5 this had to be updated, i.e. the respective dependencies had to be updated to newer versions where this requirement has been resolved.